### PR TITLE
fix(pair_stable_bluna): use lp staked to generator as reward share

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-generator"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "astroport",
  "astroport-generator-proxy-to-mirror",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-stable-bluna"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "astroport",
  "astroport-factory",
@@ -345,7 +345,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "basset"
 version = "0.1.0"
-source = "git+https://github.com/astroport-fi/anchor-bAsset-contracts.git?branch=master#912f2f4c0e500ad171c0d5deb18f079268c7daec"
+source = "git+https://github.com/Anchor-Protocol/anchor-bAsset-contracts.git?tag=v0.2.1#486f1cd495325798f884e19880180a62566b5e48"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-generator"
-version = "1.1.1"
+version = "1.1.0"
 dependencies = [
  "astroport",
  "astroport-generator-proxy-to-mirror",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-stable-bluna"
-version = "1.1.1"
+version = "1.0.1"
 dependencies = [
  "astroport",
  "astroport-factory",

--- a/contracts/pair/src/contract.rs
+++ b/contracts/pair/src/contract.rs
@@ -432,7 +432,7 @@ pub fn provide_liquidity(
 ///
 /// * **amount** is the object of type [`Uint128`]. The amount that will be mint to the recipient.
 ///
-/// * **auto_stake** is the object of type [`bool`]. Determines whether an autostake will be performed on the generator
+/// * **auto_stake** is the field of type [`bool`]. Determines whether an autostake will be performed on the generator
 fn mint_liquidity_token_message(
     deps: Deps,
     config: &Config,

--- a/contracts/pair_stable/src/contract.rs
+++ b/contracts/pair_stable/src/contract.rs
@@ -505,7 +505,7 @@ pub fn provide_liquidity(
 ///
 /// * **amount** is the object of type [`Uint128`]. The amount that will be mint to the recipient.
 ///
-/// * **auto_stake** is the object of type [`bool`]. Determines whether an autostake will be performed on the generator
+/// * **auto_stake** is the field of type [`bool`]. Determines whether an autostake will be performed on the generator
 fn mint_liquidity_token_message(
     deps: Deps,
     config: &Config,

--- a/contracts/pair_stable_bluna/Cargo.toml
+++ b/contracts/pair_stable_bluna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-stable-bluna"
-version = "1.0.0"
+version = "1.1.1"
 authors = ["Astroport"]
 edition = "2018"
 description = "An Astroport pair contract"
@@ -34,7 +34,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 cosmwasm-bignumber = "2.2.0"
 protobuf = { version = "2", features = ["with-bytes"] }
-anchor-basset = {git = "https://github.com/astroport-fi/anchor-bAsset-contracts.git", branch = "master", package = "basset"}
+anchor-basset = {git = "https://github.com/Anchor-Protocol/anchor-bAsset-contracts.git", tag = "v0.2.1", package = "basset"}
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/contracts/pair_stable_bluna/Cargo.toml
+++ b/contracts/pair_stable_bluna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-stable-bluna"
-version = "1.1.1"
+version = "1.0.1"
 authors = ["Astroport"]
 edition = "2018"
 description = "An Astroport pair contract"

--- a/contracts/pair_stable_bluna/src/contract.rs
+++ b/contracts/pair_stable_bluna/src/contract.rs
@@ -1935,7 +1935,7 @@ pub fn handle_reward(
 ///
 /// * **bluna_reward_global_index** is object of type [`Decimal256`].
 ///
-/// * **bluna_reward_user_index** is object of type [`Decimal256`].
+/// * **bluna_reward_user_index** is object of type [`Option<Decimal256>`].
 pub fn calc_user_reward(
     reward_balance: Uint128,
     previous_reward_balance: Uint128,

--- a/contracts/pair_stable_bluna/src/contract.rs
+++ b/contracts/pair_stable_bluna/src/contract.rs
@@ -1944,6 +1944,10 @@ pub fn calc_user_reward(
         ((bluna_reward_global_index - bluna_reward_user_index) * Uint256::from(user_share))
             .try_into()
             .map_err(|e| ContractError::Std(StdError::from(e)))?
+    } else if !user_share.is_zero() {
+        (bluna_reward_global_index * Uint256::from(user_share))
+            .try_into()
+            .map_err(|e| ContractError::Std(StdError::from(e)))?
     } else {
         Uint128::zero()
     };

--- a/contracts/pair_stable_bluna/src/contract.rs
+++ b/contracts/pair_stable_bluna/src/contract.rs
@@ -570,7 +570,7 @@ pub fn provide_liquidity(
 ///
 /// * **amount** is the object of type [`Uint128`]. The amount that will be mint to the recipient.
 ///
-/// * **auto_stake** is the object of type [`bool`]. Determines whether an autostake will be performed on the generator
+/// * **auto_stake** is the field of type [`bool`]. Determines whether an autostake will be performed on the generator
 fn mint_liquidity_token_message(
     deps: Deps,
     config: &Config,

--- a/contracts/pair_stable_bluna/src/contract.rs
+++ b/contracts/pair_stable_bluna/src/contract.rs
@@ -1883,19 +1883,21 @@ pub fn handle_reward(
     let mut response =
         Response::new().add_attribute("bluna_claimed_reward_to_pool", latest_reward_amount);
 
-    response.messages.push(SubMsg::new(WasmMsg::Execute {
-        contract_addr: bluna_reward_holder.to_string(),
-        funds: vec![],
-        msg: to_binary(&ExecuteMsg::Execute {
-            msgs: vec![Asset {
-                info: AssetInfo::NativeToken {
-                    denom: "uusd".to_string(),
-                },
-                amount: user_reward,
-            }
-            .into_msg(&deps.querier, receiver.clone())?],
-        })?,
-    }));
+    if !user_reward.is_zero() {
+        response.messages.push(SubMsg::new(WasmMsg::Execute {
+            contract_addr: bluna_reward_holder.to_string(),
+            funds: vec![],
+            msg: to_binary(&ExecuteMsg::Execute {
+                msgs: vec![Asset {
+                    info: AssetInfo::NativeToken {
+                        denom: "uusd".to_string(),
+                    },
+                    amount: user_reward,
+                }
+                .into_msg(&deps.querier, receiver.clone())?],
+            })?,
+        }));
+    }
 
     Ok(response
         .add_attribute("user", user)

--- a/contracts/pair_stable_bluna/src/contract.rs
+++ b/contracts/pair_stable_bluna/src/contract.rs
@@ -1226,10 +1226,12 @@ pub fn query_pending_reward(deps: Deps, _env: Env, user: String) -> StdResult<As
         },
     )?;
 
-    let global_index = BLUNA_REWARD_GLOBAL_INDEX.load(deps.storage)?;
+    let global_index = BLUNA_REWARD_GLOBAL_INDEX
+        .may_load(deps.storage)?
+        .unwrap_or_default();
     let user_index = BLUNA_REWARD_USER_INDEXES
         .may_load(deps.storage, &user)?
-        .unwrap_or_default();
+        .unwrap_or(global_index);
 
     Ok(Asset {
         info: AssetInfo::NativeToken {
@@ -1468,8 +1470,6 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, Con
                         &env,
                         &config.factory_addr,
                     )?);
-
-                BLUNA_REWARD_GLOBAL_INDEX.save(deps.storage, &cosmwasm_std::Decimal256::zero())?;
             }
             _ => return Err(ContractError::MigrationError {}),
         },
@@ -1869,7 +1869,9 @@ pub fn handle_reward(
         "uusd".to_string(),
     )?;
 
-    let bluna_reward_global_index = BLUNA_REWARD_GLOBAL_INDEX.load(deps.storage)?;
+    let bluna_reward_global_index = BLUNA_REWARD_GLOBAL_INDEX
+        .may_load(deps.storage)?
+        .unwrap_or_default();
     let bluna_reward_user_index = BLUNA_REWARD_USER_INDEXES.may_load(deps.storage, &user)?;
 
     let (bluna_reward_global_index, latest_reward_amount, user_reward) = calc_user_reward(

--- a/contracts/pair_stable_bluna/src/contract.rs
+++ b/contracts/pair_stable_bluna/src/contract.rs
@@ -1795,6 +1795,10 @@ fn claim_reward(
             },
         )?;
 
+        if user_share.is_zero() {
+            return Err(StdError::generic_err("No lp tokens staked to the generator!").into());
+        }
+
         let pool_info: PoolInfoResponse = deps.querier.query_wasm_smart(
             &config.generator,
             &GeneratorQueryMsg::PoolInfo {

--- a/contracts/pair_stable_bluna/src/state.rs
+++ b/contracts/pair_stable_bluna/src/state.rs
@@ -24,6 +24,8 @@ pub struct Config {
     pub next_amp_time: u64,
     /// Contract to claim rewards from
     pub bluna_rewarder: Addr,
+    /// The generator address used for determining the users' reward shares
+    pub generator: Addr,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/contracts/pair_stable_bluna/src/testing.rs
+++ b/contracts/pair_stable_bluna/src/testing.rs
@@ -1163,7 +1163,7 @@ fn test_calc_user_reward() {
         Uint128::new(1000000000000000000000000000),
         Uint128::new(1000000000000000000000000000),
         Decimal256::from_str("100000000000000000000000000").unwrap(),
-        Decimal256::from_str("100").unwrap(),
+        Some(Decimal256::from_str("100").unwrap()),
     )
     .unwrap_err();
 
@@ -1174,7 +1174,7 @@ fn test_calc_user_reward() {
         Uint128::new(100),
         Uint128::new(100),
         Decimal256::from_str("100").unwrap(),
-        Decimal256::from_str("100").unwrap(),
+        Some(Decimal256::from_str("100").unwrap()),
     )
     .unwrap();
     assert_eq!(
@@ -1191,7 +1191,7 @@ fn test_calc_user_reward() {
         Uint128::new(10),
         Uint128::new(100),
         Decimal256::from_str("100").unwrap(),
-        Decimal256::from_str("100").unwrap(),
+        Some(Decimal256::from_str("100").unwrap()),
     )
     .unwrap();
     assert_eq!(

--- a/contracts/pair_stable_bluna/src/testing.rs
+++ b/contracts/pair_stable_bluna/src/testing.rs
@@ -70,6 +70,7 @@ fn proper_initialization() {
             to_binary(&StablePoolParams {
                 amp: 100,
                 bluna_rewarder: "bluna_rewarder".to_string(),
+                generator: "generator".to_string(),
             })
             .unwrap(),
         ),
@@ -182,6 +183,7 @@ fn provide_liquidity() {
             to_binary(&StablePoolParams {
                 amp: 100,
                 bluna_rewarder: "bluna_rewarder".to_string(),
+                generator: "generator".to_string(),
             })
             .unwrap(),
         ),
@@ -341,6 +343,7 @@ fn withdraw_liquidity() {
             to_binary(&StablePoolParams {
                 amp: 100,
                 bluna_rewarder: "bluna_rewarder".to_string(),
+                generator: "generator".to_string(),
             })
             .unwrap(),
         ),
@@ -473,6 +476,7 @@ fn try_native_to_token() {
             to_binary(&StablePoolParams {
                 amp: 100,
                 bluna_rewarder: "bluna_rewarder".to_string(),
+                generator: "generator".to_string(),
             })
             .unwrap(),
         ),
@@ -633,6 +637,7 @@ fn try_token_to_native() {
             to_binary(&StablePoolParams {
                 amp: 100,
                 bluna_rewarder: "bluna_rewarder".to_string(),
+                generator: "generator".to_string(),
             })
             .unwrap(),
         ),
@@ -921,6 +926,7 @@ fn test_query_pool() {
             to_binary(&StablePoolParams {
                 amp: 100,
                 bluna_rewarder: "bluna_rewarder".to_string(),
+                generator: "generator".to_string(),
             })
             .unwrap(),
         ),
@@ -992,6 +998,7 @@ fn test_query_share() {
             to_binary(&StablePoolParams {
                 amp: 100,
                 bluna_rewarder: "bluna_rewarder".to_string(),
+                generator: "generator".to_string(),
             })
             .unwrap(),
         ),
@@ -1112,6 +1119,7 @@ fn test_accumulate_prices() {
                 next_amp: 100 * AMP_PRECISION,
                 next_amp_time: env.block.time.seconds(),
                 bluna_rewarder: Addr::unchecked(""),
+                generator: Addr::unchecked("generator"),
             },
             Uint128::new(case.x_amount),
             6,

--- a/contracts/pair_stable_bluna/tests/integration.rs
+++ b/contracts/pair_stable_bluna/tests/integration.rs
@@ -184,6 +184,7 @@ fn update_pair_config() {
             to_binary(&StablePoolParams {
                 amp: 100,
                 bluna_rewarder: "bluna_rewarder".to_string(),
+                generator: "generator".to_string(),
             })
             .unwrap(),
         ),

--- a/contracts/tokenomics/generator/Cargo.toml
+++ b/contracts/tokenomics/generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-generator"
-version = "1.0.0"
+version = "1.1.1"
 authors = ["Astroport"]
 edition = "2018"
 

--- a/contracts/tokenomics/generator/Cargo.toml
+++ b/contracts/tokenomics/generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-generator"
-version = "1.1.1"
+version = "1.1.0"
 authors = ["Astroport"]
 edition = "2018"
 

--- a/contracts/tokenomics/generator/src/contract.rs
+++ b/contracts/tokenomics/generator/src/contract.rs
@@ -2,9 +2,10 @@ use cosmwasm_std::{
     entry_point, from_binary, to_binary, Addr, Binary, Decimal, Deps, DepsMut, Env, MessageInfo,
     Reply, ReplyOn, Response, StdError, StdResult, SubMsg, Uint128, Uint64, WasmMsg,
 };
-use cw20::{BalanceResponse, Cw20ExecuteMsg, Cw20ReceiveMsg};
+use cw20::{BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg, Cw20ReceiveMsg, MinterResponse};
 
 use crate::error::ContractError;
+use crate::migration;
 use crate::state::{
     get_pools, update_user_balance, Config, ExecuteOnReply, PoolInfo, UserInfo, CONFIG,
     OWNERSHIP_PROPOSAL, POOL_INFO, TMP_USER_ACTION, USER_INFO,
@@ -23,7 +24,7 @@ use astroport::{
     },
     vesting::ExecuteMsg as VestingExecuteMsg,
 };
-use cw2::set_contract_version;
+use cw2::{get_contract_version, set_contract_version};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-generator";
@@ -138,6 +139,7 @@ pub fn execute(
         ExecuteMsg::Add {
             lp_token,
             alloc_point,
+            has_asset_rewards,
             reward_proxy,
         } => {
             let lp_token = addr_validate_to_lower(deps.api, &lp_token)?;
@@ -157,6 +159,7 @@ pub fn execute(
                 ExecuteOnReply::Add {
                     lp_token,
                     alloc_point,
+                    has_asset_rewards,
                     reward_proxy,
                 },
             )
@@ -164,6 +167,7 @@ pub fn execute(
         ExecuteMsg::Set {
             lp_token,
             alloc_point,
+            has_asset_rewards,
         } => {
             let lp_token = addr_validate_to_lower(deps.api, &lp_token)?;
 
@@ -179,6 +183,7 @@ pub fn execute(
                 ExecuteOnReply::Set {
                     lp_token,
                     alloc_point,
+                    has_asset_rewards,
                 },
             )
         }
@@ -320,6 +325,7 @@ pub fn add(
     env: Env,
     lp_token: Addr,
     alloc_point: Uint64,
+    has_asset_rewards: bool,
     reward_proxy: Option<String>,
 ) -> Result<Response, ContractError> {
     let mut cfg = CONFIG.load(deps.storage)?;
@@ -350,6 +356,7 @@ pub fn add(
         accumulated_proxy_rewards_per_share: Decimal::zero(),
         proxy_reward_balance_before_update: Uint128::zero(),
         orphan_proxy_rewards: Uint128::zero(),
+        has_asset_rewards,
     };
 
     CONFIG.save(deps.storage, &cfg)?;
@@ -380,6 +387,7 @@ pub fn set(
     env: Env,
     lp_token: Addr,
     alloc_point: Uint64,
+    has_asset_rewards: bool,
 ) -> Result<Response, ContractError> {
     let mut cfg = CONFIG.load(deps.storage)?;
 
@@ -392,6 +400,8 @@ pub fn set(
         .checked_sub(pool_info.alloc_point)?
         .checked_add(alloc_point)?;
     pool_info.alloc_point = alloc_point;
+
+    pool_info.has_asset_rewards = has_asset_rewards;
 
     CONFIG.save(deps.storage, &cfg)?;
     POOL_INFO.save(deps.storage, &lp_token, &pool_info)?;
@@ -527,12 +537,21 @@ fn process_after_update(deps: DepsMut, env: Env) -> Result<Response, ContractErr
                 ExecuteOnReply::Add {
                     lp_token,
                     alloc_point,
+                    has_asset_rewards,
                     reward_proxy,
-                } => add(deps, env, lp_token, alloc_point, reward_proxy),
+                } => add(
+                    deps,
+                    env,
+                    lp_token,
+                    alloc_point,
+                    has_asset_rewards,
+                    reward_proxy,
+                ),
                 ExecuteOnReply::Set {
                     lp_token,
                     alloc_point,
-                } => set(deps, env, lp_token, alloc_point),
+                    has_asset_rewards,
+                } => set(deps, env, lp_token, alloc_point, has_asset_rewards),
                 ExecuteOnReply::UpdatePool { lp_token } => update_pool(deps, env, lp_token),
                 ExecuteOnReply::Deposit {
                     lp_token,
@@ -868,6 +887,37 @@ pub fn deposit(
         vec![]
     };
 
+    let reward_msg = if pool.has_asset_rewards {
+        let total_share = match &pool.reward_proxy {
+            Some(proxy) => deps
+                .querier
+                .query_wasm_smart(proxy, &ProxyQueryMsg::Deposit {})?,
+            None => {
+                query_token_balance(
+                    &deps.querier,
+                    lp_token.clone(),
+                    env.contract.address.clone(),
+                )? - amount
+            }
+        };
+
+        let minter_response: MinterResponse = deps
+            .querier
+            .query_wasm_smart(&lp_token, &Cw20QueryMsg::Minter {})?;
+
+        vec![WasmMsg::Execute {
+            contract_addr: minter_response.minter,
+            funds: vec![],
+            msg: to_binary(&astroport::pair_stable_bluna::ExecuteMsg::ClaimReward {
+                receiver: Some(beneficiary.to_string()),
+                user_share: Some(user.amount),
+                total_share: Some(total_share),
+            })?,
+        }]
+    } else {
+        vec![]
+    };
+
     // Update user balance
     let updated_amount = user.amount.checked_add(amount)?;
     let user = update_user_balance(user, &pool, updated_amount)?;
@@ -878,6 +928,7 @@ pub fn deposit(
     Ok(Response::new()
         .add_messages(send_rewards_msg)
         .add_messages(transfer_msg)
+        .add_messages(reward_msg)
         .add_attribute("action", "deposit")
         .add_attribute("amount", amount))
 }
@@ -941,6 +992,35 @@ pub fn withdraw(
         vec![]
     };
 
+    let reward_msg = if pool.has_asset_rewards {
+        let total_share = match &pool.reward_proxy {
+            Some(proxy) => deps
+                .querier
+                .query_wasm_smart(proxy, &ProxyQueryMsg::Deposit {})?,
+            None => query_token_balance(
+                &deps.querier,
+                lp_token.clone(),
+                env.contract.address.clone(),
+            )?,
+        };
+
+        let minter_response: MinterResponse = deps
+            .querier
+            .query_wasm_smart(&lp_token, &Cw20QueryMsg::Minter {})?;
+
+        vec![WasmMsg::Execute {
+            contract_addr: minter_response.minter,
+            funds: vec![],
+            msg: to_binary(&astroport::pair_stable_bluna::ExecuteMsg::ClaimReward {
+                receiver: Some(account.to_string()),
+                user_share: Some(user.amount),
+                total_share: Some(total_share),
+            })?,
+        }]
+    } else {
+        vec![]
+    };
+
     // Update user balance
     let updated_amount = user.amount.checked_sub(amount)?;
     let user = update_user_balance(user, &pool, updated_amount)?;
@@ -956,6 +1036,7 @@ pub fn withdraw(
     Ok(Response::new()
         .add_messages(send_rewards_msg)
         .add_messages(transfer_msg)
+        .add_messages(reward_msg)
         .add_attribute("action", "withdraw")
         .add_attribute("amount", amount))
 }
@@ -1413,6 +1494,7 @@ fn query_pool_info(
         accumulated_proxy_rewards_per_share: pool.accumulated_proxy_rewards_per_share,
         proxy_reward_balance_before_update: pool.proxy_reward_balance_before_update,
         orphan_proxy_rewards: pool.orphan_proxy_rewards,
+        lp_supply,
     })
 }
 
@@ -1480,6 +1562,45 @@ pub fn calculate_rewards(env: &Env, pool: &PoolInfo, cfg: &Config) -> StdResult<
 ///
 /// * **_msg** is the object of type [`MigrateMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    Ok(Response::default())
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let contract_version = get_contract_version(deps.storage)?;
+
+    match contract_version.contract.as_ref() {
+        "astroport-generator" => match contract_version.version.as_ref() {
+            "1.0.0" => {
+                let keys = POOL_INFO
+                    .keys(deps.storage, None, None, cosmwasm_std::Order::Ascending {})
+                    .map(|v| String::from_utf8(v).map_err(StdError::from))
+                    .collect::<Result<Vec<String>, StdError>>()?;
+
+                for key in keys {
+                    let pool_info_v100 = migration::POOL_INFOV100
+                        .load(deps.storage, &Addr::unchecked(key.clone()))?;
+                    let pool_info = PoolInfo {
+                        has_asset_rewards: false,
+                        accumulated_proxy_rewards_per_share: pool_info_v100
+                            .accumulated_proxy_rewards_per_share,
+                        alloc_point: pool_info_v100.alloc_point,
+                        accumulated_rewards_per_share: pool_info_v100.accumulated_rewards_per_share,
+                        last_reward_block: pool_info_v100.last_reward_block,
+                        orphan_proxy_rewards: pool_info_v100.orphan_proxy_rewards,
+                        proxy_reward_balance_before_update: pool_info_v100
+                            .proxy_reward_balance_before_update,
+                        reward_proxy: pool_info_v100.reward_proxy,
+                    };
+                    POOL_INFO.save(deps.storage, &Addr::unchecked(key), &pool_info)?;
+                }
+            }
+            _ => return Err(ContractError::MigrationError {}),
+        },
+        _ => return Err(ContractError::MigrationError {}),
+    };
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::new()
+        .add_attribute("previous_contract_name", &contract_version.contract)
+        .add_attribute("previous_contract_version", &contract_version.version)
+        .add_attribute("new_contract_name", CONTRACT_NAME)
+        .add_attribute("new_contract_version", CONTRACT_VERSION))
 }

--- a/contracts/tokenomics/generator/src/contract.rs
+++ b/contracts/tokenomics/generator/src/contract.rs
@@ -316,6 +316,8 @@ pub fn execute_update_config(
 ///
 /// * **alloc_point** is the object of type [`Uint64`].
 ///
+/// * **has_asset_rewards** is the object of type [`bool`].
+///
 /// * **reward_proxy** is an [`Option`] field object of type [`String`].
 ///
 /// ##Executor
@@ -379,6 +381,8 @@ pub fn add(
 /// * **lp_token** is the object of type [`Addr`].
 ///
 /// * **alloc_point** is the object of type [`Uint64`].
+///
+/// * **has_asset_rewards** is the object of type [`bool`].
 ///
 /// ##Executor
 /// Can only be called by the owner

--- a/contracts/tokenomics/generator/src/contract.rs
+++ b/contracts/tokenomics/generator/src/contract.rs
@@ -316,7 +316,7 @@ pub fn execute_update_config(
 ///
 /// * **alloc_point** is the object of type [`Uint64`].
 ///
-/// * **has_asset_rewards** is the object of type [`bool`].
+/// * **has_asset_rewards** is the field of type [`bool`].
 ///
 /// * **reward_proxy** is an [`Option`] field object of type [`String`].
 ///
@@ -382,7 +382,7 @@ pub fn add(
 ///
 /// * **alloc_point** is the object of type [`Uint64`].
 ///
-/// * **has_asset_rewards** is the object of type [`bool`].
+/// * **has_asset_rewards** is the field of type [`bool`].
 ///
 /// ##Executor
 /// Can only be called by the owner

--- a/contracts/tokenomics/generator/src/error.rs
+++ b/contracts/tokenomics/generator/src/error.rs
@@ -25,6 +25,9 @@ pub enum ContractError {
 
     #[error("Insufficient amount of orphan rewards!")]
     OrphanRewardsTooSmall {},
+
+    #[error("Contract can't be migrated!")]
+    MigrationError {},
 }
 
 impl From<OverflowError> for ContractError {

--- a/contracts/tokenomics/generator/src/lib.rs
+++ b/contracts/tokenomics/generator/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod contract;
 pub mod error;
+pub mod migration;
 pub mod state;

--- a/contracts/tokenomics/generator/src/lib.rs
+++ b/contracts/tokenomics/generator/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod contract;
 pub mod error;
-pub mod migration;
+mod migration;
 pub mod state;

--- a/contracts/tokenomics/generator/src/migration.rs
+++ b/contracts/tokenomics/generator/src/migration.rs
@@ -1,0 +1,24 @@
+use cosmwasm_std::{Addr, Decimal, Uint128, Uint64};
+use cw_storage_plus::Map;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// ## Description
+/// This structure describes the main information of pool
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct PoolInfoV100 {
+    /// Allocation point is used to control reward distribution among the pools
+    pub alloc_point: Uint64,
+    /// Accumulated amount of reward per share unit. Used for reward calculations
+    pub last_reward_block: Uint64,
+    pub accumulated_rewards_per_share: Decimal,
+    /// the reward proxy contract
+    pub reward_proxy: Option<Addr>,
+    pub accumulated_proxy_rewards_per_share: Decimal,
+    /// for calculation of new proxy rewards
+    pub proxy_reward_balance_before_update: Uint128,
+    /// the orphan proxy rewards which are left by emergency withdrawals
+    pub orphan_proxy_rewards: Uint128,
+}
+
+pub const POOL_INFOV100: Map<&Addr, PoolInfoV100> = Map::new("pool_info");

--- a/contracts/tokenomics/generator/src/state.rs
+++ b/contracts/tokenomics/generator/src/state.rs
@@ -33,6 +33,8 @@ pub struct PoolInfo {
     pub proxy_reward_balance_before_update: Uint128,
     /// the orphan proxy rewards which are left by emergency withdrawals
     pub orphan_proxy_rewards: Uint128,
+    /// The pool has assets giving additional rewards
+    pub has_asset_rewards: bool,
 }
 
 /// ## Description
@@ -65,6 +67,8 @@ pub enum ExecuteOnReply {
         lp_token: Addr,
         /// the allocation point for LP token contract
         alloc_point: Uint64,
+        /// The flag determines whether the pool has its asset related rewards or not
+        has_asset_rewards: bool,
         /// the reward proxy contract
         reward_proxy: Option<String>,
     },
@@ -74,6 +78,8 @@ pub enum ExecuteOnReply {
         lp_token: Addr,
         /// the allocation point for LP token contract
         alloc_point: Uint64,
+        /// The flag determines whether the pool has its asset related rewards or not
+        has_asset_rewards: bool,
     },
     /// Updates reward variables of the given pool to be up-to-date
     UpdatePool {

--- a/contracts/tokenomics/generator/tests/integration.rs
+++ b/contracts/tokenomics/generator/tests/integration.rs
@@ -104,6 +104,7 @@ fn disabling_pool() {
     let msg = GeneratorExecuteMsg::Set {
         alloc_point: Uint64::new(0),
         lp_token: lp_cny_eur_instance.to_string(),
+        has_asset_rewards: false,
     };
 
     app.execute_contract(owner.clone(), generator_instance.clone(), &msg, &[])
@@ -113,6 +114,7 @@ fn disabling_pool() {
     let msg_eur_usd = GeneratorExecuteMsg::Set {
         alloc_point: Uint64::new(0),
         lp_token: lp_eur_usd_instance.to_string(),
+        has_asset_rewards: false,
     };
     app.execute_contract(owner.clone(), generator_instance.clone(), &msg_eur_usd, &[])
         .unwrap();
@@ -576,12 +578,14 @@ fn generator_without_reward_proxies() {
     let msg = GeneratorExecuteMsg::Set {
         alloc_point: Uint64::new(60),
         lp_token: lp_cny_eur_instance.to_string(),
+        has_asset_rewards: false,
     };
     app.execute_contract(owner.clone(), generator_instance.clone(), &msg, &[])
         .unwrap();
     let msg = GeneratorExecuteMsg::Set {
         alloc_point: Uint64::new(40),
         lp_token: lp_eur_usd_instance.to_string(),
+        has_asset_rewards: false,
     };
     app.execute_contract(owner.clone(), generator_instance.clone(), &msg, &[])
         .unwrap();
@@ -777,6 +781,7 @@ fn generator_with_mirror_reward_proxy() {
         alloc_point: Uint64::from(100u64),
         reward_proxy: Some(proxy_to_mirror_instance.to_string()),
         lp_token: lp_cny_eur_instance.to_string(),
+        has_asset_rewards: false,
     };
     assert_eq!(
         app.execute_contract(
@@ -980,12 +985,14 @@ fn generator_with_mirror_reward_proxy() {
     let msg = GeneratorExecuteMsg::Set {
         alloc_point: Uint64::new(60),
         lp_token: lp_cny_eur_instance.to_string(),
+        has_asset_rewards: false,
     };
     app.execute_contract(owner.clone(), generator_instance.clone(), &msg, &[])
         .unwrap();
     let msg = GeneratorExecuteMsg::Set {
         alloc_point: Uint64::new(40),
         lp_token: lp_eur_usd_instance.to_string(),
+        has_asset_rewards: false,
     };
     app.execute_contract(owner.clone(), generator_instance.clone(), &msg, &[])
         .unwrap();
@@ -1465,6 +1472,7 @@ fn register_lp_tokens_in_generator(
             alloc_point: Uint64::from(100u64),
             reward_proxy: reward_proxy.map(|v| v.to_string()),
             lp_token: (*lp).to_string(),
+            has_asset_rewards: false,
         };
         app.execute_contract(
             Addr::unchecked(OWNER),

--- a/packages/astroport/src/generator.rs
+++ b/packages/astroport/src/generator.rs
@@ -41,6 +41,8 @@ pub enum ExecuteMsg {
         lp_token: String,
         /// the allocation point of liquidity pool
         alloc_point: Uint64,
+        /// The flag determines whether the pool has its asset related rewards or not
+        has_asset_rewards: bool,
         /// the reward proxy contract
         reward_proxy: Option<String>,
     },
@@ -53,6 +55,8 @@ pub enum ExecuteMsg {
         lp_token: String,
         /// the allocation point of liquidity pool
         alloc_point: Uint64,
+        /// The flag determines whether the pool has its asset related rewards or not
+        has_asset_rewards: bool,
     },
     /// ## Description
     /// Updates reward variables for all pools
@@ -196,6 +200,8 @@ pub struct PoolInfoResponse {
     pub proxy_reward_balance_before_update: Uint128,
     /// the orphan proxy rewards which are left by emergency withdrawals
     pub orphan_proxy_rewards: Uint128,
+    /// Total amount of lp tokens staked to the pool
+    pub lp_supply: Uint128,
 }
 
 /// ## Description

--- a/packages/astroport/src/pair_stable_bluna.rs
+++ b/packages/astroport/src/pair_stable_bluna.rs
@@ -38,17 +38,22 @@ pub enum ExecuteMsg {
     ClaimReward {
         /// An address which will receive the reward
         receiver: Option<String>,
-        /// Only the generator can use this parameter on changing the amount of user's staked lp tokens
-        user_share: Option<Uint128>,
-        /// Only the generator can use this parameter on changing the amount of user's staked lp tokens
-        total_share: Option<Uint128>,
+    },
+    /// Claims the Bluna reward on changing of user lp token amount deposited to the generator
+    ClaimRewardByGenerator {
+        /// The user whose lp token amount is changing
+        user: String,
+        /// The user's lp token amount before the change
+        user_share: Uint128,
+        /// The total lp token amount deposited to the generator before the change
+        total_share: Uint128,
     },
     /// Callback for distributing Bluna reward
     HandleReward {
         previous_reward_balance: Uint128,
+        user: Addr,
         user_share: Uint128,
         total_share: Uint128,
-        user: Addr,
         receiver: Option<Addr>,
     },
 }

--- a/packages/astroport/src/pair_stable_bluna.rs
+++ b/packages/astroport/src/pair_stable_bluna.rs
@@ -35,7 +35,14 @@ pub enum ExecuteMsg {
     /// Update pair config if required
     UpdateConfig { params: Binary },
     /// Claims the Bluna reward and sends it to the receiver
-    ClaimReward { receiver: Option<String> },
+    ClaimReward {
+        /// An address which will receive the reward
+        receiver: Option<String>,
+        /// Only the generator can use this parameter on changing the amount of user's staked lp tokens
+        user_share: Option<Uint128>,
+        /// Only the generator can use this parameter on changing the amount of user's staked lp tokens
+        total_share: Option<Uint128>,
+    },
     /// Callback for distributing Bluna reward
     HandleReward {
         previous_reward_balance: Uint128,
@@ -74,6 +81,7 @@ pub enum QueryMsg {
 pub struct StablePoolParams {
     pub amp: u64,
     pub bluna_rewarder: String,
+    pub generator: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -81,6 +89,7 @@ pub struct StablePoolParams {
 pub struct StablePoolConfig {
     pub amp: Decimal,
     pub bluna_rewarder: Addr,
+    pub generator: Addr,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -94,4 +103,5 @@ pub enum StablePoolUpdateParams {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {
     pub bluna_rewarder: String,
+    pub generator: String,
 }


### PR DESCRIPTION
Fixes #184

Use lp token amount staked to the generator as the share for bluna rewards distribution