### PR TITLE
Fix comment in contract:provide_liquidity

### DIFF
--- a/contracts/pair/src/contract.rs
+++ b/contracts/pair/src/contract.rs
@@ -382,7 +382,7 @@ pub fn provide_liquidity(
         assert_slippage_tolerance(slippage_tolerance, &deposits, &pools)?;
 
         // min(1, 2)
-        // 1. sqrt(deposit_0 * exchange_rate_0_to_1 * deposit_0) * (total_share / sqrt(pool_0 * pool_1))
+        // 1. sqrt(deposit_0 * exchange_rate_0_to_1 * deposit_0) * (total_share / sqrt(pool_0 * pool_0))
         // == deposit_0 * total_share / pool_0
         // 2. sqrt(deposit_1 * exchange_rate_1_to_0 * deposit_1) * (total_share / sqrt(pool_1 * pool_1))
         // == deposit_1 * total_share / pool_1


### PR DESCRIPTION
Fix comment explaining share to be minted when adding liquidity.