### PR TITLE
fix: Use saturating_sub in compute_swap

### DIFF
--- a/contracts/pair/src/contract.rs
+++ b/contracts/pair/src/contract.rs
@@ -1289,3 +1289,23 @@ pub fn pool_info(querier: QuerierWrapper, config: &Config) -> StdResult<(Vec<Ass
 
     Ok((pools, total_share))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::contract::compute_swap;
+    use cosmwasm_std::{Decimal, Uint128};
+
+    #[test]
+    fn compute_swap_does_not_panic_on_spread_calc() {
+        let offer_pool = Uint128::from(u128::MAX / 2);
+        let ask_pool = Uint128::from(u128::MAX / 1000000000);
+        let offer_amount = Uint128::from(1000000000u128);
+        let commission_rate = Decimal::permille(3);
+
+        let (return_amount, spread_amount, commission_amount) =
+            compute_swap(offer_pool, ask_pool, offer_amount, commission_rate).unwrap();
+        assert_eq!(return_amount, Uint128::from(2u128));
+        assert_eq!(spread_amount, Uint128::zero());
+        assert_eq!(commission_amount, Uint128::zero());
+    }
+}

--- a/contracts/pair/src/contract.rs
+++ b/contracts/pair/src/contract.rs
@@ -1114,7 +1114,7 @@ pub fn compute_swap(
 
     // Calculate spread & commission
     let spread_amount: Uint256 =
-        (offer_amount * Decimal256::from_ratio(ask_pool, offer_pool)) - return_amount;
+        (offer_amount * Decimal256::from_ratio(ask_pool, offer_pool)).saturating_sub(return_amount);
     let commission_amount: Uint256 = return_amount * commission_rate;
 
     // The commision (minus the part that goes to the Maker contract) will be absorbed by the pool


### PR DESCRIPTION
In some cases line 1117 in pair contract.rs panics because of subtraction overflow when computing `spread_amount`. This PR simply replaces the regular subtraction with `saturating_sub` to avoid this.