### PR TITLE
fix(PCL): safe withdraw; increase numerical methods accuracy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-concentrated"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "astroport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-concentrated"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "astroport",

--- a/contracts/pair_concentrated/Cargo.toml
+++ b/contracts/pair_concentrated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-concentrated"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport concentrated liquidity pair"

--- a/contracts/pair_concentrated/Cargo.toml
+++ b/contracts/pair_concentrated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-concentrated"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport concentrated liquidity pair"

--- a/contracts/pair_concentrated/src/consts.rs
+++ b/contracts/pair_concentrated/src/consts.rs
@@ -16,8 +16,8 @@ pub const N: Decimal256 = Decimal256::raw(2000000000000000000);
 pub const FEE_TOL: Decimal256 = Decimal256::raw(1000000000000000);
 /// N ^ 2
 pub const N_POW2: Decimal256 = Decimal256::raw(4000000000000000000);
-/// 1e-3
-pub const TOL: Decimal256 = Decimal256::raw(1000000000000000);
+/// 1e-5
+pub const TOL: Decimal256 = Decimal256::raw(10000000000000);
 /// halfpow tolerance (1e-10)
 pub const HALFPOW_TOL: Decimal256 = Decimal256::raw(100000000);
 /// 2.0

--- a/contracts/pair_concentrated/src/contract.rs
+++ b/contracts/pair_concentrated/src/contract.rs
@@ -903,7 +903,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
         "astroport-pair-concentrated" => match contract_version.version.as_ref() {
             "1.0.0" | "1.1.0" | "1.1.1" | "1.1.2" => migrate_config(deps.storage)?,
             "1.1.4" => migrate_config_from_v140(deps.storage)?,
-            "1.2.1" => {}
+            "1.2.0" | "1.2.1" => {}
             _ => return Err(ContractError::MigrationError {}),
         },
         _ => return Err(ContractError::MigrationError {}),

--- a/contracts/pair_concentrated/src/contract.rs
+++ b/contracts/pair_concentrated/src/contract.rs
@@ -633,15 +633,13 @@ fn withdraw_liquidity(
     if assets.is_empty() {
         // Usual withdraw (balanced)
         burn_amount = amount;
-        refund_assets = get_share_in_assets(&pools, amount, total_share)?;
+        refund_assets = get_share_in_assets(&pools, amount, total_share);
     } else {
         return Err(StdError::generic_err("Imbalanced withdraw is currently disabled").into());
     }
 
     // decrease XCP
     let mut xs = pools.iter().map(|a| a.amount).collect_vec();
-
-    let (_, old_real_price) = calc_last_prices(&xs, &config, &env)?;
 
     xs[0] -= refund_assets[0].amount;
     xs[1] -= refund_assets[1].amount;
@@ -679,8 +677,6 @@ fn withdraw_liquidity(
         )?
         .into(),
     );
-
-    accumulate_prices(&env, &mut config, old_real_price);
 
     if config.track_asset_balances {
         for (i, pool) in pools.iter().enumerate() {

--- a/contracts/pair_concentrated/src/contract.rs
+++ b/contracts/pair_concentrated/src/contract.rs
@@ -903,6 +903,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
         "astroport-pair-concentrated" => match contract_version.version.as_ref() {
             "1.0.0" | "1.1.0" | "1.1.1" | "1.1.2" => migrate_config(deps.storage)?,
             "1.1.4" => migrate_config_from_v140(deps.storage)?,
+            "1.2.1" => {}
             _ => return Err(ContractError::MigrationError {}),
         },
         _ => return Err(ContractError::MigrationError {}),

--- a/contracts/pair_concentrated/src/math/math_decimal.rs
+++ b/contracts/pair_concentrated/src/math/math_decimal.rs
@@ -223,6 +223,30 @@ mod tests {
     }
 
     #[test]
+    fn test_real_case() {
+        let x0 = 1173700.016159;
+        let x1 = 0.800244312479334221;
+        let offer_amount = 1.0;
+        let amp = 40.0;
+        let gamma = 0.000145;
+        let d = 2064.855164704653967332;
+
+        println!("Pool before [{} {}]", x0, x1);
+        let new_x1 = newton_y(
+            &[f64_to_dec(x0 + offer_amount), f64_to_dec(x1)],
+            f64_to_dec(amp),
+            f64_to_dec(gamma),
+            f64_to_dec(d),
+            1,
+        )
+        .unwrap();
+        let new_x1 = dec_to_f64(new_x1);
+        println!("Pool after [{} {}]", x0 + offer_amount, new_x1);
+        println!("Diff [{} {}]", offer_amount, new_x1 - x1);
+        assert!(new_x1 < x1, "new x1 {new_x1} should be less than x1 {x1}");
+    }
+
+    #[test]
     fn test_derivatives() {
         let a_f64 = 3500f64;
         let gamma_f64 = 0.000145;

--- a/contracts/pair_concentrated/src/math/math_f64.rs
+++ b/contracts/pair_concentrated/src/math/math_f64.rs
@@ -1,7 +1,7 @@
 use crate::consts::MAX_ITER;
 
 const N: f64 = 2.0;
-const TOL: f64 = 1e-3;
+const TOL: f64 = 1e-5;
 
 pub fn f(d: f64, x: &[f64], a: f64, gamma: f64) -> f64 {
     let k0 = (x[0] * x[1] * N * N) / d.powi(2);

--- a/contracts/pair_concentrated/src/queries.rs
+++ b/contracts/pair_concentrated/src/queries.rs
@@ -104,7 +104,7 @@ fn query_share(deps: Deps, amount: Uint128) -> Result<Vec<Asset>, ContractError>
         &precisions,
     )?;
     let total_share = query_supply(&deps.querier, &config.pair_info.liquidity_token)?;
-    let refund_assets = get_share_in_assets(&pools, amount, total_share)?;
+    let refund_assets = get_share_in_assets(&pools, amount, total_share);
 
     let refund_assets = refund_assets
         .into_iter()

--- a/contracts/pair_concentrated/src/utils.rs
+++ b/contracts/pair_concentrated/src/utils.rs
@@ -124,7 +124,7 @@ pub(crate) fn get_share_in_assets(
     pools: &[DecimalAsset],
     amount: Uint128,
     total_share: Uint128,
-) -> StdResult<Vec<DecimalAsset>> {
+) -> Vec<DecimalAsset> {
     let share_ratio = if !total_share.is_zero() {
         Decimal256::from_ratio(amount, total_share)
     } else {
@@ -133,11 +133,9 @@ pub(crate) fn get_share_in_assets(
 
     pools
         .iter()
-        .map(|pool| {
-            Ok(DecimalAsset {
-                info: pool.info.clone(),
-                amount: pool.amount * share_ratio,
-            })
+        .map(|pool| DecimalAsset {
+            info: pool.info.clone(),
+            amount: pool.amount * share_ratio,
         })
         .collect()
 }

--- a/contracts/pair_concentrated_inj/src/consts.rs
+++ b/contracts/pair_concentrated_inj/src/consts.rs
@@ -16,8 +16,8 @@ pub const N: Decimal256 = Decimal256::raw(2000000000000000000);
 pub const FEE_TOL: Decimal256 = Decimal256::raw(1000000000000000);
 /// N ^ 2
 pub const N_POW2: Decimal256 = Decimal256::raw(4000000000000000000);
-/// 1e-3
-pub const TOL: Decimal256 = Decimal256::raw(1000000000000000);
+/// 1e-5
+pub const TOL: Decimal256 = Decimal256::raw(10000000000000);
 /// halfpow tolerance (1e-10)
 pub const HALFPOW_TOL: Decimal256 = Decimal256::raw(100000000);
 /// 2.0

--- a/contracts/pair_concentrated_inj/src/math/math_decimal.rs
+++ b/contracts/pair_concentrated_inj/src/math/math_decimal.rs
@@ -223,6 +223,30 @@ mod tests {
     }
 
     #[test]
+    fn test_real_case() {
+        let x0 = 1173700.016159;
+        let x1 = 0.800244312479334221;
+        let offer_amount = 1.0;
+        let amp = 40.0;
+        let gamma = 0.000145;
+        let d = 2064.855164704653967332;
+
+        println!("Pool before [{} {}]", x0, x1);
+        let new_x1 = newton_y(
+            &[f64_to_dec(x0 + offer_amount), f64_to_dec(x1)],
+            f64_to_dec(amp),
+            f64_to_dec(gamma),
+            f64_to_dec(d),
+            1,
+        )
+        .unwrap();
+        let new_x1 = dec_to_f64(new_x1);
+        println!("Pool after [{} {}]", x0 + offer_amount, new_x1);
+        println!("Diff [{} {}]", offer_amount, new_x1 - x1);
+        assert!(new_x1 < x1, "new x1 {new_x1} should be less than x1 {x1}");
+    }
+
+    #[test]
     fn test_derivatives() {
         let a_f64 = 3500f64;
         let gamma_f64 = 0.000145;

--- a/contracts/pair_concentrated_inj/src/math/math_f64.rs
+++ b/contracts/pair_concentrated_inj/src/math/math_f64.rs
@@ -1,7 +1,7 @@
 use crate::consts::MAX_ITER;
 
 const N: f64 = 2.0;
-const TOL: f64 = 1e-3;
+const TOL: f64 = 1e-5;
 
 pub fn f(d: f64, x: &[f64], a: f64, gamma: f64) -> f64 {
     let k0 = (x[0] * x[1] * N * N) / d.powi(2);

--- a/contracts/pair_concentrated_inj/src/migrate.rs
+++ b/contracts/pair_concentrated_inj/src/migrate.rs
@@ -15,7 +15,7 @@ use astroport_pair_concentrated::state::Config as CLConfig;
 use crate::state::{AmpGamma, Config, PoolParams, PoolState, PriceState, CONFIG, OBSERVATIONS};
 
 const MIGRATE_FROM: &str = "astroport-pair-concentrated";
-const MIGRATION_VERSION: &str = "1.2.0";
+const MIGRATION_VERSION: &str = "1.2.1";
 
 /// Manages the contract migration.
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/pair_concentrated_inj/src/migrate.rs
+++ b/contracts/pair_concentrated_inj/src/migrate.rs
@@ -15,7 +15,7 @@ use astroport_pair_concentrated::state::Config as CLConfig;
 use crate::state::{AmpGamma, Config, PoolParams, PoolState, PriceState, CONFIG, OBSERVATIONS};
 
 const MIGRATE_FROM: &str = "astroport-pair-concentrated";
-const MIGRATION_VERSION: &str = "1.2.1";
+const MIGRATION_VERSION: &str = "1.2.2";
 
 /// Manages the contract migration.
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport"
-version = "2.10.0"
+version = "2.10.1"
 authors = ["Astroport"]
 edition = "2021"
 description = "Common Astroport types, queriers and other utils"


### PR DESCRIPTION
1. Make PCL withdraw endpoint as safe as possible;
2. Increase numerical methods accuracy for both PCL and PCL with orderbook integration.