### PR TITLE
feat: Add contract astroport-pair-xyk-sale-tax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "astroport 3.8.0",
  "astroport-factory 1.6.0",
  "astroport-mocks",
+ "astroport-pair",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,8 +530,8 @@ dependencies = [
 name = "astroport-pair-xyk-sale-tax"
 version = "1.4.0"
 dependencies = [
- "astroport",
- "astroport-factory",
+ "astroport 3.8.0",
+ "astroport-factory 1.6.0",
  "astroport-mocks",
  "astroport-token",
  "cosmwasm-schema",
@@ -703,10 +703,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
-name = "base64"
-version = "0.13.1"
+name = "base16ct"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -771,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
+checksum = "128a44527fc0d6abf05f9eda748b9027536e12dff93f5acc8449f51583309350"
 
 [[package]]
 name = "byteorder"
@@ -833,22 +839,22 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e272708a9745dad8b591ef8a718571512130f2b39b33e3d7a27c558e3069394"
+checksum = "1ca101fbf2f76723711a30ea3771ef312ec3ec254ad021b237871ed802f9f175"
 dependencies = [
  "digest 0.10.7",
  "ed25519-zebra",
- "k256",
+ "k256 0.13.1",
  "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296db6a3caca5283425ae0cf347f4e46999ba3f6620dbea8939a0e00347831ce"
+checksum = "c73d2dd292f60e42849d2b07c03d809cf31e128a4299a805abd6d24553bcaaf5"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -879,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5e05a95fd2a420cca50f4e94eb7e70648dac64db45e90403997ebefeb143bd"
+checksum = "2a44d3f9c25b2f864737c6605a98f2e4675d53fd8bbc7cf4d7c02475661a793d"
 dependencies = [
  "base64",
  "bnum",
@@ -933,6 +939,18 @@ name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -1063,7 +1081,7 @@ dependencies = [
  "cw-utils 1.0.1",
  "derivative",
  "itertools 0.10.5",
- "k256",
+ "k256 0.11.6",
  "prost 0.9.0",
  "schemars",
  "serde",
@@ -1424,6 +1442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1478,10 +1507,24 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+dependencies = [
+ "der 0.7.8",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.5",
+ "rfc6979 0.4.0",
+ "signature 2.1.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -1511,16 +1554,35 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.3",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -1593,6 +1655,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1677,6 +1749,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1696,7 +1769,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1834,9 +1918,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
  "sha2 0.10.7",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.16.8",
+ "elliptic-curve 0.13.5",
+ "once_cell",
+ "sha2 0.10.7",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -2017,8 +2115,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.8",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -2313,9 +2421,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -2400,10 +2518,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.8",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -2520,6 +2652,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "sim"
 version = "0.1.0"
 source = "git+https://github.com/astroport-fi/astroport-sims?branch=main#744b25583373e964a9f9a1c51949a67bd68e6a17"
@@ -2561,7 +2703,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "astroport-pair-xyk-sale-tax"
+version = "1.4.0"
+dependencies = [
+ "astroport",
+ "astroport-factory",
+ "astroport-mocks",
+ "astroport-token",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 1.0.1",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
+ "integer-sqrt",
+ "proptest",
+ "prost 0.11.9",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "astroport-pcl-common"
 version = "1.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,26 @@ dependencies = [
 
 [[package]]
 name = "astroport"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195a7441515817c0d114ec3bebe9faa21393781f796c179c38c75e3cfb9fb4ec"
+dependencies = [
+ "astroport-circular-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 1.0.2",
+ "cw20 0.15.1",
+ "cw3",
+ "itertools 0.10.5",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "astroport"
 version = "3.8.0"
 dependencies = [
- "astroport-circular-buffer",
+ "astroport-circular-buffer 0.1.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-asset",
@@ -75,6 +92,18 @@ dependencies = [
 [[package]]
 name = "astroport-circular-buffer"
 version = "0.1.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "thiserror",
+]
+
+[[package]]
+name = "astroport-circular-buffer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac37467245383e7a6baeaaabc22dfd85a7b70ff5d693f757ba63bbc6e39d2c3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -137,7 +166,7 @@ version = "1.6.0"
 dependencies = [
  "anyhow",
  "astroport 3.8.0",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -178,7 +207,7 @@ dependencies = [
  "astroport-mocks",
  "astroport-native-coin-registry",
  "astroport-nft",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-pair-stable",
  "astroport-staking",
  "astroport-token",
@@ -236,7 +265,7 @@ dependencies = [
  "astroport 3.8.0",
  "astroport-factory 1.6.0",
  "astroport-native-coin-registry",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-pair-stable",
  "astroport-vesting",
  "cosmwasm-schema",
@@ -261,7 +290,7 @@ dependencies = [
  "astroport-factory 1.6.0",
  "astroport-generator",
  "astroport-native-coin-registry",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-pair-stable",
  "astroport-token",
  "astroport-whitelist",
@@ -287,7 +316,7 @@ dependencies = [
  "astroport-factory 1.6.0",
  "astroport-governance",
  "astroport-native-coin-registry",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-pair-stable",
  "astroport-token",
  "cosmwasm-schema",
@@ -308,7 +337,7 @@ dependencies = [
  "astroport-factory 1.6.0",
  "astroport-generator",
  "astroport-native-coin-registry",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-pair-concentrated 2.3.0",
  "astroport-pair-stable",
  "astroport-shared-multisig",
@@ -379,7 +408,7 @@ dependencies = [
  "astroport 3.8.0",
  "astroport-factory 1.6.0",
  "astroport-native-coin-registry",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-pair-stable",
  "astroport-token",
  "cosmwasm-schema",
@@ -409,6 +438,24 @@ dependencies = [
  "integer-sqrt",
  "proptest",
  "prost 0.11.9",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "astroport-pair"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd96bc64722440636ed6267a6945ccce076231a08467d6d46a4af4c4ff062c69"
+dependencies = [
+ "astroport 3.6.1",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 1.0.2",
+ "cw2 0.15.1",
+ "cw20 0.15.1",
+ "integer-sqrt",
  "protobuf",
  "thiserror",
 ]
@@ -482,7 +529,7 @@ version = "2.3.0"
 dependencies = [
  "anyhow",
  "astroport 3.8.0",
- "astroport-circular-buffer",
+ "astroport-circular-buffer 0.1.0",
  "astroport-factory 1.6.0",
  "astroport-mocks",
  "astroport-native-coin-registry",
@@ -507,7 +554,7 @@ version = "3.4.0"
 dependencies = [
  "anyhow",
  "astroport 3.8.0",
- "astroport-circular-buffer",
+ "astroport-circular-buffer 0.1.0",
  "astroport-factory 1.6.0",
  "astroport-mocks",
  "astroport-native-coin-registry",
@@ -528,12 +575,13 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-xyk-sale-tax"
-version = "1.4.0"
+version = "1.6.0"
 dependencies = [
  "astroport 3.8.0",
  "astroport-factory 1.6.0",
  "astroport-mocks",
- "astroport-pair",
+ "astroport-pair 1.5.0",
+ "astroport-pair 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -545,6 +593,7 @@ dependencies = [
  "proptest",
  "prost 0.11.9",
  "protobuf",
+ "test-case",
  "thiserror",
 ]
 
@@ -570,7 +619,7 @@ dependencies = [
  "anyhow",
  "astroport 3.8.0",
  "astroport-factory 1.6.0",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -589,7 +638,7 @@ dependencies = [
  "astroport 3.8.0",
  "astroport-generator",
  "astroport-mocks",
- "astroport-pair",
+ "astroport-pair 1.5.0",
  "astroport-pair-concentrated 2.3.0",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2735,9 +2784,9 @@ dependencies = [
 
 [[package]]
 name = "test-case"
-version = "3.2.1"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f1e820b7f1d95a0cdbf97a5df9de10e1be731983ab943e56703ac1b8e9d425"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
 dependencies = [
  "test-case-macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "astroport-circular-buffer 0.1.0",
  "cosmwasm-schema",
@@ -115,7 +115,7 @@ dependencies = [
 name = "astroport-cw20-ics20"
 version = "1.1.1"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.1",
@@ -165,7 +165,7 @@ name = "astroport-factory"
 version = "1.6.0"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-pair 1.5.0",
  "astroport-token",
  "cosmwasm-schema",
@@ -185,7 +185,7 @@ dependencies = [
 name = "astroport-fee-granter"
 version = "0.1.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmos-sdk-proto",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -201,7 +201,7 @@ name = "astroport-generator"
 version = "2.3.2"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-governance",
  "astroport-mocks",
@@ -236,7 +236,7 @@ dependencies = [
 name = "astroport-generator-proxy-template"
 version = "0.0.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -250,7 +250,7 @@ name = "astroport-governance"
 version = "1.2.0"
 source = "git+https://github.com/astroport-fi/astroport-governance#f0ef7c6dde76fc77ce360262923366a5cde3c3f8"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -262,7 +262,7 @@ name = "astroport-incentives"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-native-coin-registry",
  "astroport-pair 1.5.0",
@@ -286,7 +286,7 @@ name = "astroport-liquidity-manager"
 version = "1.0.3"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-generator",
  "astroport-native-coin-registry",
@@ -311,7 +311,7 @@ name = "astroport-maker"
 version = "1.3.1"
 dependencies = [
  "astro-satellite-package",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-escrow-fee-distributor",
  "astroport-factory 1.6.0",
  "astroport-governance",
@@ -333,7 +333,7 @@ name = "astroport-mocks"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-generator",
  "astroport-native-coin-registry",
@@ -361,7 +361,7 @@ dependencies = [
 name = "astroport-native-coin-registry"
 version = "1.0.1"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -375,7 +375,7 @@ dependencies = [
 name = "astroport-native-coin-wrapper"
 version = "0.1.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -405,7 +405,7 @@ name = "astroport-oracle"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-native-coin-registry",
  "astroport-pair 1.5.0",
@@ -425,7 +425,7 @@ dependencies = [
 name = "astroport-pair"
 version = "1.5.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-mocks",
  "astroport-token",
@@ -464,7 +464,7 @@ dependencies = [
 name = "astroport-pair-astro-xastro"
 version = "1.0.3"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-pair-bonded",
  "astroport-staking",
@@ -483,7 +483,7 @@ dependencies = [
 name = "astroport-pair-bonded"
 version = "1.0.1"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
@@ -495,7 +495,7 @@ dependencies = [
 name = "astroport-pair-bonded-template"
 version = "1.0.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-pair-bonded",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -528,7 +528,7 @@ name = "astroport-pair-concentrated"
 version = "2.3.0"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-circular-buffer 0.1.0",
  "astroport-factory 1.6.0",
  "astroport-mocks",
@@ -553,7 +553,7 @@ name = "astroport-pair-stable"
 version = "3.4.0"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-circular-buffer 0.1.0",
  "astroport-factory 1.6.0",
  "astroport-mocks",
@@ -577,7 +577,7 @@ dependencies = [
 name = "astroport-pair-xyk-sale-tax"
 version = "1.6.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-mocks",
  "astroport-pair 1.5.0",
@@ -602,7 +602,7 @@ name = "astroport-pcl-common"
 version = "1.1.0"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -617,7 +617,7 @@ name = "astroport-router"
 version = "1.2.0"
 dependencies = [
  "anyhow",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-factory 1.6.0",
  "astroport-pair 1.5.0",
  "astroport-token",
@@ -635,7 +635,7 @@ dependencies = [
 name = "astroport-shared-multisig"
 version = "1.0.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-generator",
  "astroport-mocks",
  "astroport-pair 1.5.0",
@@ -655,7 +655,7 @@ dependencies = [
 name = "astroport-staking"
 version = "1.1.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-token",
  "astroport-xastro-token",
  "cosmwasm-schema",
@@ -673,7 +673,7 @@ dependencies = [
 name = "astroport-token"
 version = "1.1.1"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2 0.15.1",
@@ -686,7 +686,7 @@ dependencies = [
 name = "astroport-vesting"
 version = "1.3.2"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -702,7 +702,7 @@ dependencies = [
 name = "astroport-whitelist"
 version = "1.0.1"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw1-whitelist",
@@ -714,7 +714,7 @@ dependencies = [
 name = "astroport-xastro-outpost-token"
 version = "1.0.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 0.15.1",
@@ -729,7 +729,7 @@ dependencies = [
 name = "astroport-xastro-token"
 version = "1.1.0"
 dependencies = [
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 0.15.1",
@@ -1764,7 +1764,7 @@ version = "0.0.0"
 source = "git+https://github.com/astroport-fi/astro-generator-proxy-contracts?branch=main#e573a8f8542b99015cac910f024a5f20fd793f3c"
 dependencies = [
  "ap-valkyrie",
- "astroport 3.8.0",
+ "astroport 3.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "ap-valkyrie"
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "astro-satellite-package"
 version = "0.1.0"
-source = "git+https://github.com/astroport-fi/astroport_ibc#ffb48ebfd7dbbc010cf86c9b02bad236c456fca0"
+source = "git+https://github.com/astroport-fi/astroport_ibc#61f3cf90ac7e48de93224e906171ebe206d7f860"
 dependencies = [
  "astroport-governance",
  "cosmwasm-schema",
@@ -62,7 +62,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-asset",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "cw20 0.15.1",
  "cw3",
  "injective-math",
@@ -89,11 +89,11 @@ dependencies = [
  "astroport 3.8.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-controllers 1.1.0",
+ "cw-controllers 1.1.1",
  "cw-storage-plus 1.1.0",
- "cw-utils 1.0.1",
- "cw2 1.1.0",
- "cw20 1.1.0",
+ "cw-utils 1.0.2",
+ "cw2 1.1.1",
+ "cw20 1.1.1",
  "cw20-ics20",
  "schemars",
  "semver",
@@ -143,7 +143,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test 0.15.1",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "itertools 0.10.5",
@@ -162,8 +162,8 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test 0.16.5 (git+https://github.com/astroport-fi/cw-multi-test.git?rev=269a2c829d1ad25d67caa4600f72d2a21fb8fdeb)",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
- "cw2 1.1.0",
+ "cw-utils 1.0.2",
+ "cw2 1.1.1",
  "thiserror",
 ]
 
@@ -187,7 +187,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "cw1-whitelist",
  "cw2 0.15.1",
  "cw20 0.15.1",
@@ -243,10 +243,10 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test 0.16.5 (git+https://github.com/astroport-fi/cw-multi-test?branch=astroport_cozy_fork)",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
- "cw2 1.1.0",
- "cw20 1.1.0",
- "cw20-base 1.1.0",
+ "cw-utils 1.0.2",
+ "cw2 1.1.1",
+ "cw20 1.1.1",
+ "cw20-base 1.1.1",
  "itertools 0.11.0",
  "proptest",
  "thiserror",
@@ -320,7 +320,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 0.16.5 (git+https://github.com/astroport-fi/cw-multi-test.git?rev=269a2c829d1ad25d67caa4600f72d2a21fb8fdeb)",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "cw20 0.15.1",
  "cw3",
  "injective-cosmwasm",
@@ -403,7 +403,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "integer-sqrt",
@@ -515,7 +515,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "derivative",
@@ -538,7 +538,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "integer-sqrt",
@@ -558,7 +558,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
- "cw20 1.1.0",
+ "cw20 1.1.1",
  "itertools 0.11.0",
  "thiserror",
 ]
@@ -594,8 +594,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
- "cw2 1.1.0",
+ "cw-utils 1.0.2",
+ "cw2 1.1.1",
  "cw20 0.15.1",
  "cw3",
  "itertools 0.10.5",
@@ -613,7 +613,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test 0.15.1",
  "cw-storage-plus 0.15.1",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "cw2 0.15.1",
  "cw20 0.15.1",
  "protobuf",
@@ -754,9 +754,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
@@ -784,26 +784,17 @@ checksum = "128a44527fc0d6abf05f9eda748b9027536e12dff93f5acc8449f51583309350"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -823,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "cosmos-sdk-proto"
@@ -840,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca101fbf2f76723711a30ea3771ef312ec3ec254ad021b237871ed802f9f175"
+checksum = "a6fb22494cf7d23d0c348740e06e5c742070b2991fd41db77bba0bcfbae1a723"
 dependencies = [
  "digest 0.10.7",
  "ed25519-zebra",
@@ -853,18 +844,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73d2dd292f60e42849d2b07c03d809cf31e128a4299a805abd6d24553bcaaf5"
+checksum = "6e199424486ea97d6b211db6387fd72e26b4a439d40cc23140b2d8305728055b"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df41ea55f2946b6b43579659eec048cc2f66e8c8e2e3652fc5e5e476f673856"
+checksum = "fef683a9c1c4eabd6d31515719d0d2cc66952c4c87f7eb192bfc90384517dc34"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -875,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43609e92ce1b9368aa951b334dd354a2d0dd4d484931a5f83ae10e12a26c8ba9"
+checksum = "9567025acbb4c0c008178393eb53b3ac3c2e492c25949d3bf415b9cbe80772d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -886,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a44d3f9c25b2f864737c6605a98f2e4675d53fd8bbc7cf4d7c02475661a793d"
+checksum = "7d89d680fb60439b7c5947b15f9c84b961b88d1f8a3b20c4bd178a3f87db8bae"
 dependencies = [
  "base64",
  "bnum",
@@ -900,15 +891,15 @@ dependencies = [
  "schemars",
  "serde",
  "serde-json-wasm",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800aaddd70ba915e19bf3d2d992aa3689d8767857727fdd3b414df4fd52d2aa1"
+checksum = "54a1c574d30feffe4b8121e61e839c231a5ce21901221d2fb4d5c945968a4f00"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -1001,7 +992,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-address-like",
  "cw-storage-plus 1.1.0",
- "cw20 1.1.0",
+ "cw20 1.1.1",
  "thiserror",
 ]
 
@@ -1021,14 +1012,14 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d8edce4b78785f36413f67387e4be7d0cb7d032b5d4164bcc024f9c3f3f2ea"
+checksum = "23b129ca74fa41111fd2e1727426532556dc63973420343b659f5c072b85d789"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "schemars",
  "serde",
  "thiserror",
@@ -1061,13 +1052,13 @@ dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "derivative",
  "itertools 0.11.0",
  "prost 0.11.9",
  "schemars",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -1079,7 +1070,7 @@ dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "derivative",
  "itertools 0.10.5",
  "k256 0.11.6",
@@ -1174,13 +1165,13 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
+checksum = "1b9f351a4e4d81ef7c890e44d903f8c0bdcdc00f094fd3a181eaf70c0eec7a3a"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.1.0",
+ "cw2 1.1.1",
  "schemars",
  "semver",
  "serde",
@@ -1255,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ac2dc7a55ad64173ca1e0a46697c31b7a5c51342f55a1e84a724da4eb99908"
+checksum = "9431d14f64f49e41c6ef5561ed11a5391c417d0cb16455dea8cdcb9037a8d197"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1306,13 +1297,13 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011c45920f8200bd5d32d4fe52502506f64f2f75651ab408054d4cfc75ca3a9b"
+checksum = "786e9da5e937f473cecd2463e81384c1af65d0f6398bbd851be7655487c55492"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 1.0.1",
+ "cw-utils 1.0.2",
  "schemars",
  "serde",
 ]
@@ -1353,16 +1344,16 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3ad456059901a36cfa68b596d85d579c3df2b797dae9950dc34c27e14e995f"
+checksum = "09558f87fd3d5e4a479761051b3f98ee2fa723d9e484b5679b6058ad0eadf8f1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
- "cw-utils 1.0.1",
- "cw2 1.1.0",
- "cw20 1.1.0",
+ "cw-utils 1.0.2",
+ "cw2 1.1.1",
+ "cw20 1.1.1",
  "schemars",
  "semver",
  "serde",
@@ -1389,14 +1380,14 @@ dependencies = [
 
 [[package]]
 name = "cw3"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171af3d9127de6805a7dd819fb070c7d2f6c3ea85f4193f42cef259f0a7f33d5"
+checksum = "1d056ec33ec146554aa1d16c9535763341db75589a47743c006c377e62b54034"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 1.0.1",
- "cw20 1.1.0",
+ "cw-utils 1.0.2",
+ "cw20 1.1.1",
  "schemars",
  "serde",
  "thiserror",
@@ -1454,9 +1445,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derivative"
@@ -1498,9 +1492,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "ecdsa"
@@ -1522,7 +1516,7 @@ checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der 0.7.8",
  "digest 0.10.7",
- "elliptic-curve 0.13.5",
+ "elliptic-curve 0.13.6",
  "rfc6979 0.4.0",
  "signature 2.1.0",
  "spki 0.7.2",
@@ -1571,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.3",
@@ -1590,23 +1584,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1647,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -1848,9 +1831,9 @@ checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "injective-cosmwasm"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4295a2d118cae0e21bba1c856464f6678b5db907cb085b3723d04efb65fa0d0d"
+checksum = "ea4feaba1e0816808642abaed4eb369799c863a759f77bb71a15daca076d9874"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -1866,14 +1849,13 @@ dependencies = [
 
 [[package]]
 name = "injective-math"
-version = "0.1.18"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a4077c240f057406b6efa4bf94bb9e8f86c83687d917c562a02da15466d0a9"
+checksum = "e8b28dc06633a0fc1ac0345d350ff6ecead60989119a985c94053ce9448c1aa9"
 dependencies = [
  "bigint",
  "cosmwasm-std",
  "ethereum-types",
- "num",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1921,7 +1903,7 @@ dependencies = [
  "cfg-if",
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1932,9 +1914,9 @@ checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.8",
- "elliptic-curve 0.13.5",
+ "elliptic-curve 0.13.6",
  "once_cell",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "signature 2.1.0",
 ]
 
@@ -1946,27 +1928,27 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1982,40 +1964,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,43 +1975,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -2093,13 +2008,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets",
 ]
@@ -2129,6 +2044,12 @@ dependencies = [
  "der 0.7.8",
  "spki 0.7.2",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2162,22 +2083,22 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -2321,9 +2242,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2411,10 +2332,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.8.2"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rfc6979"
@@ -2454,11 +2384,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.38.6"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2485,9 +2415,9 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -2497,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2543,15 +2473,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -2576,13 +2506,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2598,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -2615,7 +2545,7 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2633,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2672,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "snafu"
@@ -2757,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2774,13 +2704,13 @@ checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]
@@ -2822,7 +2752,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2834,52 +2764,53 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.25"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
+ "powerfmt",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -2895,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uint"
@@ -2931,9 +2862,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unindent"
@@ -3069,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -3084,45 +3015,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "contracts/pair_concentrated",
 #  "contracts/pair_concentrated_inj", TODO: rewrite OB liquidity deployment
   "contracts/pair_astro_xastro",
+  "contracts/pair_xyk_sale_tax",
   "contracts/router",
   "contracts/token",
   "contracts/whitelist",

--- a/contracts/pair_xyk_sale_tax/.cargo/config
+++ b/contracts/pair_xyk_sale_tax/.cargo/config
@@ -1,0 +1,6 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+integration-test = "test --test integration"
+schema = "run --example pair_schema"

--- a/contracts/pair_xyk_sale_tax/.editorconfig
+++ b/contracts/pair_xyk_sale_tax/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4

--- a/contracts/pair_xyk_sale_tax/Cargo.toml
+++ b/contracts/pair_xyk_sale_tax/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = { version = "1.0" }
 protobuf = { version = "2", features = ["with-bytes"] }
 cosmwasm-schema = "1.1"
 cw-utils = "1.0.1"
+astroport-pair = { path = "../pair", features = ["library"] }
 
 [dev-dependencies]
 astroport-token = { path = "../token" }

--- a/contracts/pair_xyk_sale_tax/Cargo.toml
+++ b/contracts/pair_xyk_sale_tax/Cargo.toml
@@ -42,3 +42,5 @@ astroport-factory = { path = "../factory" }
 proptest = "1.0"
 prost = "0.11.5"
 astroport-mocks = { path = "../../packages/astroport_mocks/" }
+astroport-pair-1_3_1 = { package = "astroport-pair", version = "1.3.1", features = ["library"] }
+test-case = "3.3.1"

--- a/contracts/pair_xyk_sale_tax/Cargo.toml
+++ b/contracts/pair_xyk_sale_tax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astroport-pair-xyk-sale-tax"
 version = "1.4.0"
-authors = ["Astroport"]
+authors = ["Astroport", "Sturdy"]
 edition = "2021"
 description = "The Astroport constant product pool contract implementation"
 license = "MIT"

--- a/contracts/pair_xyk_sale_tax/Cargo.toml
+++ b/contracts/pair_xyk_sale_tax/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "astroport-pair-xyk-sale-tax"
+version = "1.4.0"
+authors = ["Astroport"]
+edition = "2021"
+description = "The Astroport constant product pool contract implementation"
+license = "MIT"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for quicker tests, cargo test --lib
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+library = []
+
+[dependencies]
+integer-sqrt = "0.1"
+astroport = { path = "../../packages/astroport", default-features = false }
+cw2 = "0.15"
+cw20 = "0.15"
+cosmwasm-std = "1.1"
+cw-storage-plus = "0.15"
+thiserror = { version = "1.0" }
+protobuf = { version = "2", features = ["with-bytes"] }
+cosmwasm-schema = "1.1"
+cw-utils = "1.0.1"
+
+[dev-dependencies]
+astroport-token = { path = "../token" }
+astroport-factory = { path = "../factory" }
+proptest = "1.0"
+prost = "0.11.5"
+astroport-mocks = { path = "../../packages/astroport_mocks/" }

--- a/contracts/pair_xyk_sale_tax/Cargo.toml
+++ b/contracts/pair_xyk_sale_tax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-xyk-sale-tax"
-version = "1.4.0"
+version = "1.6.0"
 authors = ["Astroport", "Sturdy"]
 edition = "2021"
 description = "The Astroport constant product pool contract implementation"

--- a/contracts/pair_xyk_sale_tax/README.md
+++ b/contracts/pair_xyk_sale_tax/README.md
@@ -1,0 +1,301 @@
+# Astroport Constant Product Pair
+
+The constant product pool uses the widely known xy=k formula. More details around how the pool functions can be found [here](https://docs.astroport.fi/astroport/astroport/astro-pools/constant-product-pools).
+
+---
+
+## Liquidity Providers
+
+A user can provide liquidity to a constant product pool by calling `provide_liquidity`. Users can also withdraw liquidity by calling `withdraw_liquidity`.
+
+Whenever liquidity is deposited into a pool, special tokens known as "liquidity tokens" are minted to the provider’s address, in proportion to how much liquidity they contributed to the pool. These tokens are a representation of a liquidity provider’s contribution to a pool. Whenever a trade occurs, the `lp_commission` is distributed pro-rata to all LPs in the pool at the moment of the trade. To receive the underlying liquidity back plus accrued LP fees, LPs must burn their liquidity tokens.
+
+When providing liquidity from a smart contract, the most important thing to keep in mind is that the amount of tokens deposited into a pool and the amount of tokens withdrawn later from the pool will most likely not be the same. This is because of the way constant product pools work where, as the token prices in the pool change, so do the respective token amounts that a LP can withdraw.
+
+As an example, let's say the global ratio between two tokens x:y is 10:2 (i.e. 1 x = 0.2 y), but the current ratio between the tokens in an Astroport pair is 5:2 (1 x = 0.4 y). Let's also say that someone may decide to LP in the x:y Astroport pool at the current 5:2 ratio. As the Astroport pool gets arbitraged to the global ratio, the amount of x & y tokens that the LP can withdraw changes because the total amounts of x & y tokens in the pool also change.
+
+> Note that before executing the `provide_liqudity` operation, a user must allow the pool contract to take tokens from their wallet
+
+### Slippage Tolerance for Providing Liquidity
+
+If a user specifies a slippage tolerance when they provide liquidity in a constant product pool, the pool contract makes sure that the transaction goes through only if the pool price does not change more than tolerance.
+
+As an example, let's say someone LPs in a pool and specifies a 1% slippage tolerance. The user LPs 200 UST and 1 `ASSET`. With a 1% slippage tolerance, `amountUSTMin` (the minimum amount of UST to LP) should be set to 198 UST, and `amountASSETMin` (the minimum amount of `ASSET` to LP) should be set to .99 `ASSET`. This means that, in a worst case scenario, liquidity will be added at a pool rate of 198 `ASSET`/1 UST or 202.02 UST/1 `ASSET` (200 UST + .99 `ASSET`). If the contract cannot add liquidity within these bounds (because the pool ratio changed more than the tolerance), the transaction will revert.
+
+## Traders
+
+### Slippage Tolerance for Swaps
+
+Astroport has two options to protect traders against slippage during swaps:
+
+1. Providing `max_spread`
+The spread is calculated as the difference between the ask amount (using the constant pool price) before and after the swap operation. Once `max_spread` is set, it will be compared against the actual swap spread. In case the swap spread exceeds the provided max limit, the swap will fail.
+
+Note that the spread is calculated before commission deduction in order to properly represent the pool's ratio change.
+
+2. Providing `max_spread` + `belief_price`
+If `belief_price` is provided in combination with `max_spread`, the pool will check the difference between the return amount (using `belief_price`) and the real pool price.
+
+Please note that Astroport has the default value for the spread set to 0.5% and the max allowed spread set to 50%.
+
+## InstantiateMsg
+
+Initializes a new x*y=k pair.
+
+```json
+{
+  "token_code_id": 123,
+  "factory_addr": "terra...",
+  "asset_infos": [
+    {
+      "token": {
+        "contract_addr": "terra..."
+      }
+    },
+    {
+      "native_token": {
+        "denom": "uusd"
+      }
+    }
+  ],
+  "init_params": "<base64_encoded_json_string: optional binary serialised parameters for custom pool types>"
+}
+```
+
+## ExecuteMsg
+
+### `receive`
+
+Withdraws liquidity or assets that were swapped to (ask assets in a swap operation).
+
+```json
+{
+  "receive": {
+    "sender": "terra...",
+    "amount": "123",
+    "msg": "<base64_encoded_json_string>"
+  }
+}
+```
+
+### `provide_liquidity`
+
+Provides liquidity by sending a user's native or token assets to the pool.
+
+__NOTE__: you should increase your token allowance for the pool before providing liquidity!
+
+1. Providing Liquidity Without Specifying Slippage Tolerance
+
+```json
+  {
+    "provide_liquidity": {
+      "assets": [
+        {
+          "info": {
+            "token": {
+              "contract_addr": "terra..."
+            }
+          },
+          "amount": "1000000"
+        },
+        {
+          "info": {
+            "native_token": {
+              "denom": "uusd"
+            }
+          },
+          "amount": "1000000"
+        }
+      ],
+      "auto_stake": false,
+      "receiver": "terra..."
+    }
+  }
+```
+
+2. Providing Liquidity With Slippage Tolerance
+
+  ```json
+  {
+    "provide_liquidity": {
+      "assets": [
+        {
+          "info": {
+            "token": {
+              "contract_addr": "terra..."
+            }
+          },
+          "amount": "1000000"
+        },
+        {
+          "info": {
+            "native_token": {
+              "denom": "uusd"
+            }
+          },
+          "amount": "1000000"
+        }
+      ],
+      "slippage_tolerance": "0.01",
+      "auto_stake": false,
+      "receiver": "terra..."
+    }
+  }
+```
+
+### `withdraw_liquidity`
+
+Burn LP tokens and withdraw liquidity from a pool. This call must be sent to a LP token contract associated with the pool from which you want to withdraw liquidity from.
+
+```json
+  {
+    "withdraw_liquidity": {}
+  }
+```
+
+### `swap`
+
+Perform a swap. `offer_asset` is your source asset and `to` is the address that will receive the ask assets. All fields are optional except `offer_asset`.
+
+NOTE: You should increase token allowance before swap.
+
+```json
+  {
+    "swap": {
+      "offer_asset": {
+        "info": {
+          "native_token": {
+            "denom": "uluna"
+          }
+        },
+        "amount": "123"
+      },
+      "belief_price": "123",
+      "max_spread": "123",
+      "to": "terra..."
+    }
+  }
+```
+
+### `update_config`
+
+The contract configuration cannot be updated.
+
+```json
+  {
+    "update_config": {
+      "params": "<base64_encoded_json_string>"
+    }
+  }
+```
+
+## QueryMsg
+
+All query messages are described below. A custom struct is defined for each query response.
+
+### `pair`
+
+Retrieve a pair's configuration (type, assets traded in it etc)
+
+```json
+{
+  "pair": {}
+}
+```
+
+### `pool`
+
+Returns the amount of tokens in the pool for all assets as well as the amount of LP tokens issued.
+
+```json
+{
+  "pool": {}
+}
+```
+
+### `config`
+
+Get the pair contract configuration.
+
+```json
+{
+  "config": {}
+}
+```
+
+### `share`
+
+Return the amount of assets someone would get from the pool if they were to burn a specific amount of LP tokens.
+
+```json
+{
+  "share": {
+    "amount": "123"
+  }
+}
+```
+
+### `simulation`
+
+Simulates a swap and returns the spread and commission amounts.
+
+```json
+{
+  "simulation": {
+    "offer_asset": {
+      "info": {
+        "native_token": {
+          "denom": "uusd"
+        }
+      },
+      "amount": "1000000"
+    }
+  }
+}
+```
+
+### `reverse_simulation`
+
+Reverse simulates a swap (specifies the ask instead of the offer) and returns the offer amount, spread and commission.
+
+```json
+{
+  "reverse_simulation": {
+    "ask_asset": {
+      "info": {
+        "token": {
+          "contract_addr": "terra..."
+        }
+      },
+      "amount": "1000000"
+    }
+  }
+}
+```
+
+### `cumulative_prices`
+
+Returns the cumulative prices for the assets in the pair.
+
+```json
+{
+  "cumulative_prices": {}
+}
+```
+
+### `asset_balance_at`
+
+Returns the balance of the specified asset that was in the pool just preceeding the moment of the specified block height creation. It will return None (null) if the balance was not tracked up to the specified block height.
+
+```json
+{
+  "asset_balance_at": {
+    "asset_info": {
+      "native_token": {
+        "denom": "stake"
+      }
+    },
+    "block_height": "12345678"
+  }
+}
+

--- a/contracts/pair_xyk_sale_tax/README.md
+++ b/contracts/pair_xyk_sale_tax/README.md
@@ -1,6 +1,8 @@
-# Astroport Constant Product Pair
+# Astroport Constant Product Pair with Sale Tax
 
 The constant product pool uses the widely known xy=k formula. More details around how the pool functions can be found [here](https://docs.astroport.fi/astroport/astroport/astro-pools/constant-product-pools).
+
+This is a modified version of the standard Astroport XYK pair which adds a configurable sale tax. The tax can be added on each of the assets in the pair and is taken on the offered asset before calculating the return amount.
 
 ---
 
@@ -29,18 +31,18 @@ As an example, let's say someone LPs in a pool and specifies a 1% slippage toler
 Astroport has two options to protect traders against slippage during swaps:
 
 1. Providing `max_spread`
-The spread is calculated as the difference between the ask amount (using the constant pool price) before and after the swap operation. Once `max_spread` is set, it will be compared against the actual swap spread. In case the swap spread exceeds the provided max limit, the swap will fail.
+   The spread is calculated as the difference between the ask amount (using the constant pool price) before and after the swap operation. Once `max_spread` is set, it will be compared against the actual swap spread. In case the swap spread exceeds the provided max limit, the swap will fail.
 
 Note that the spread is calculated before commission deduction in order to properly represent the pool's ratio change.
 
 2. Providing `max_spread` + `belief_price`
-If `belief_price` is provided in combination with `max_spread`, the pool will check the difference between the return amount (using `belief_price`) and the real pool price.
+   If `belief_price` is provided in combination with `max_spread`, the pool will check the difference between the return amount (using `belief_price`) and the real pool price.
 
 Please note that Astroport has the default value for the spread set to 0.5% and the max allowed spread set to 50%.
 
 ## InstantiateMsg
 
-Initializes a new x*y=k pair.
+Initializes a new x\*y=k pair.
 
 ```json
 {
@@ -82,65 +84,65 @@ Withdraws liquidity or assets that were swapped to (ask assets in a swap operati
 
 Provides liquidity by sending a user's native or token assets to the pool.
 
-__NOTE__: you should increase your token allowance for the pool before providing liquidity!
+**NOTE**: you should increase your token allowance for the pool before providing liquidity!
 
 1. Providing Liquidity Without Specifying Slippage Tolerance
 
 ```json
-  {
-    "provide_liquidity": {
-      "assets": [
-        {
-          "info": {
-            "token": {
-              "contract_addr": "terra..."
-            }
-          },
-          "amount": "1000000"
+{
+  "provide_liquidity": {
+    "assets": [
+      {
+        "info": {
+          "token": {
+            "contract_addr": "terra..."
+          }
         },
-        {
-          "info": {
-            "native_token": {
-              "denom": "uusd"
-            }
-          },
-          "amount": "1000000"
-        }
-      ],
-      "auto_stake": false,
-      "receiver": "terra..."
-    }
+        "amount": "1000000"
+      },
+      {
+        "info": {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        "amount": "1000000"
+      }
+    ],
+    "auto_stake": false,
+    "receiver": "terra..."
   }
+}
 ```
 
 2. Providing Liquidity With Slippage Tolerance
 
-  ```json
-  {
-    "provide_liquidity": {
-      "assets": [
-        {
-          "info": {
-            "token": {
-              "contract_addr": "terra..."
-            }
-          },
-          "amount": "1000000"
+```json
+{
+  "provide_liquidity": {
+    "assets": [
+      {
+        "info": {
+          "token": {
+            "contract_addr": "terra..."
+          }
         },
-        {
-          "info": {
-            "native_token": {
-              "denom": "uusd"
-            }
-          },
-          "amount": "1000000"
-        }
-      ],
-      "slippage_tolerance": "0.01",
-      "auto_stake": false,
-      "receiver": "terra..."
-    }
+        "amount": "1000000"
+      },
+      {
+        "info": {
+          "native_token": {
+            "denom": "uusd"
+          }
+        },
+        "amount": "1000000"
+      }
+    ],
+    "slippage_tolerance": "0.01",
+    "auto_stake": false,
+    "receiver": "terra..."
   }
+}
 ```
 
 ### `withdraw_liquidity`
@@ -148,9 +150,9 @@ __NOTE__: you should increase your token allowance for the pool before providing
 Burn LP tokens and withdraw liquidity from a pool. This call must be sent to a LP token contract associated with the pool from which you want to withdraw liquidity from.
 
 ```json
-  {
-    "withdraw_liquidity": {}
-  }
+{
+  "withdraw_liquidity": {}
+}
 ```
 
 ### `swap`
@@ -160,21 +162,21 @@ Perform a swap. `offer_asset` is your source asset and `to` is the address that 
 NOTE: You should increase token allowance before swap.
 
 ```json
-  {
-    "swap": {
-      "offer_asset": {
-        "info": {
-          "native_token": {
-            "denom": "uluna"
-          }
-        },
-        "amount": "123"
+{
+  "swap": {
+    "offer_asset": {
+      "info": {
+        "native_token": {
+          "denom": "uluna"
+        }
       },
-      "belief_price": "123",
-      "max_spread": "123",
-      "to": "terra..."
-    }
+      "amount": "123"
+    },
+    "belief_price": "123",
+    "max_spread": "123",
+    "to": "terra..."
   }
+}
 ```
 
 ### `update_config`
@@ -182,11 +184,11 @@ NOTE: You should increase token allowance before swap.
 The contract configuration cannot be updated.
 
 ```json
-  {
-    "update_config": {
-      "params": "<base64_encoded_json_string>"
-    }
+{
+  "update_config": {
+    "params": "<base64_encoded_json_string>"
   }
+}
 ```
 
 ## QueryMsg
@@ -298,4 +300,4 @@ Returns the balance of the specified asset that was in the pool just preceeding 
     "block_height": "12345678"
   }
 }
-
+```

--- a/contracts/pair_xyk_sale_tax/examples/pair_schema.rs
+++ b/contracts/pair_xyk_sale_tax/examples/pair_schema.rs
@@ -1,0 +1,11 @@
+use astroport::pair::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cosmwasm_schema::write_api;
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        query: QueryMsg,
+        execute: ExecuteMsg,
+        migrate: MigrateMsg,
+    }
+}

--- a/contracts/pair_xyk_sale_tax/examples/pair_schema.rs
+++ b/contracts/pair_xyk_sale_tax/examples/pair_schema.rs
@@ -1,4 +1,5 @@
-use astroport::pair::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use astroport::pair::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use astroport::pair_xyk_sale_tax::MigrateMsg;
 use cosmwasm_schema::write_api;
 
 fn main() {

--- a/contracts/pair_xyk_sale_tax/rustfmt.toml
+++ b/contracts/pair_xyk_sale_tax/rustfmt.toml
@@ -1,0 +1,15 @@
+# stable
+newline_style = "unix"
+hard_tabs = false
+tab_spaces = 4
+
+# unstable... should we require `rustup run nightly cargo fmt` ?
+# or just update the style guide when they are stable?
+#fn_single_line = true
+#format_code_in_doc_comments = true
+#overflow_delimited_expr = true
+#reorder_impl_items = true
+#struct_field_align_threshold = 20
+#struct_lit_single_line = true
+#report_todo = "Always"
+

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -69,7 +69,7 @@ pub fn instantiate(
             contract_addr: env.contract.address.clone(),
             liquidity_token: Addr::unchecked(""),
             asset_infos: msg.asset_infos.clone(),
-            pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
+            pair_type: PairType::Xyk {},
         },
         factory_addr: deps.api.addr_validate(msg.factory_addr.as_str())?,
         block_time_last: 0,

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -1371,6 +1371,11 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
             track_asset_balances: old_config.track_asset_balances,
         };
         CONFIG.save(deps.storage, &new_config)?;
+    } else {
+        return Err(StdError::generic_err(
+            "Incompatible contract name. Only astroport-pair supported.",
+        )
+        .into());
     }
 
     Ok(Response::default())

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -1324,11 +1324,12 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
 
     // If migrating from default xyk pair, we must make some state changes
     if contract_version.contract == "astroport-pair" {
-        if contract_version.version != "1.4.0" {
-            return Err(StdError::generic_err(
-                "Incompatible version of astroport-pair. Only 1.4.0 supported.",
+        match contract_version.version.as_str() {
+            "1.3.0" | "1.3.1" | "1.4.0" => {}
+            _ => return Err(StdError::generic_err(
+                "Incompatible version of astroport-pair. Only 1.3.0, 1.3.1, and 1.4.0 supported.",
             )
-            .into());
+            .into()),
         }
 
         // Read old config

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -1349,7 +1349,7 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
         match contract_version.version.as_str() {
             "1.3.0" | "1.3.1" | "1.4.0" | "1.5.0" => {}
             _ => return Err(StdError::generic_err(
-                "Incompatible version of astroport-pair. Only 1.3.0, 1.3.1, and 1.4.0 supported.",
+                "Incompatible version of astroport-pair. Only 1.3.0, 1.3.1, 1.4.0, and 1.5.0 supported.",
             )
             .into()),
         }

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -1378,7 +1378,18 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
         .into());
     }
 
-    Ok(Response::default())
+    // Set new cw2 data
+    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::default().add_attributes([
+        ("previous_contract_name", contract_version.contract.as_str()),
+        (
+            "previous_contract_version",
+            contract_version.version.as_str(),
+        ),
+        ("new_contract_name", CONTRACT_NAME),
+        ("new_contract_version", CONTRACT_VERSION),
+    ]))
 }
 
 /// Returns the total amount of assets in the pool as well as the total amount of LP tokens currently minted.

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -1,0 +1,1292 @@
+use std::convert::TryInto;
+use std::str::FromStr;
+use std::vec;
+
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    attr, from_binary, to_binary, Addr, Binary, CosmosMsg, Decimal, Decimal256, Deps, DepsMut, Env,
+    Fraction, MessageInfo, QuerierWrapper, Reply, ReplyOn, Response, StdError, StdResult, SubMsg,
+    SubMsgResponse, SubMsgResult, Uint128, Uint256, Uint64, WasmMsg,
+};
+use cw2::set_contract_version;
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg, MinterResponse};
+
+use astroport::asset::{
+    addr_opt_validate, check_swap_parameters, format_lp_token_name, Asset, AssetInfo, CoinsExt,
+    PairInfo, MINIMUM_LIQUIDITY_AMOUNT,
+};
+use astroport::factory::PairType;
+use astroport::generator::Cw20HookMsg as GeneratorHookMsg;
+use astroport::pair::{
+    ConfigResponse, XYKPoolConfig, XYKPoolParams, XYKPoolUpdateParams, DEFAULT_SLIPPAGE,
+    MAX_ALLOWED_SLIPPAGE,
+};
+use astroport::pair::{
+    CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, PoolResponse,
+    QueryMsg, ReverseSimulationResponse, SimulationResponse, TWAP_PRECISION,
+};
+use astroport::querier::{query_factory_config, query_fee_info, query_supply};
+use astroport::{token::InstantiateMsg as TokenInstantiateMsg, U256};
+use cw_utils::parse_instantiate_response_data;
+
+use crate::error::ContractError;
+use crate::state::{Config, BALANCES, CONFIG};
+
+/// Contract name that is used for migration.
+const CONTRACT_NAME: &str = "astroport-pair";
+/// Contract version that is used for migration.
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// A `reply` call code ID used for sub-messages.
+const INSTANTIATE_TOKEN_REPLY_ID: u64 = 1;
+
+/// Creates a new contract with the specified parameters in the [`InstantiateMsg`].
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    if msg.asset_infos.len() != 2 {
+        return Err(StdError::generic_err("asset_infos must contain exactly two elements").into());
+    }
+
+    msg.asset_infos[0].check(deps.api)?;
+    msg.asset_infos[1].check(deps.api)?;
+
+    if msg.asset_infos[0] == msg.asset_infos[1] {
+        return Err(ContractError::DoublingAssets {});
+    }
+
+    let mut track_asset_balances = false;
+
+    if let Some(init_params) = msg.init_params {
+        let params: XYKPoolParams = from_binary(&init_params)?;
+        track_asset_balances = params.track_asset_balances.unwrap_or_default();
+    }
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let config = Config {
+        pair_info: PairInfo {
+            contract_addr: env.contract.address.clone(),
+            liquidity_token: Addr::unchecked(""),
+            asset_infos: msg.asset_infos.clone(),
+            pair_type: PairType::Xyk {},
+        },
+        factory_addr: deps.api.addr_validate(msg.factory_addr.as_str())?,
+        block_time_last: 0,
+        price0_cumulative_last: Uint128::zero(),
+        price1_cumulative_last: Uint128::zero(),
+        track_asset_balances,
+    };
+
+    if track_asset_balances {
+        for asset in &config.pair_info.asset_infos {
+            BALANCES.save(deps.storage, asset, &Uint128::zero(), env.block.height)?;
+        }
+    }
+
+    CONFIG.save(deps.storage, &config)?;
+
+    let token_name = format_lp_token_name(&msg.asset_infos, &deps.querier)?;
+
+    // Create the LP token contract
+    let sub_msg: Vec<SubMsg> = vec![SubMsg {
+        msg: WasmMsg::Instantiate {
+            code_id: msg.token_code_id,
+            msg: to_binary(&TokenInstantiateMsg {
+                name: token_name,
+                symbol: "uLP".to_string(),
+                decimals: 6,
+                initial_balances: vec![],
+                mint: Some(MinterResponse {
+                    minter: env.contract.address.to_string(),
+                    cap: None,
+                }),
+                marketing: None,
+            })?,
+            funds: vec![],
+            admin: None,
+            label: String::from("Astroport LP token"),
+        }
+        .into(),
+        id: INSTANTIATE_TOKEN_REPLY_ID,
+        gas_limit: None,
+        reply_on: ReplyOn::Success,
+    }];
+
+    Ok(Response::new().add_submessages(sub_msg).add_attribute(
+        "asset_balances_tracking".to_owned(),
+        if config.track_asset_balances {
+            "enabled"
+        } else {
+            "disabled"
+        }
+        .to_owned(),
+    ))
+}
+
+/// The entry point to the contract for processing replies from submessages.
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+    match msg {
+        Reply {
+            id: INSTANTIATE_TOKEN_REPLY_ID,
+            result:
+                SubMsgResult::Ok(SubMsgResponse {
+                    data: Some(data), ..
+                }),
+        } => {
+            let mut config: Config = CONFIG.load(deps.storage)?;
+
+            if config.pair_info.liquidity_token != Addr::unchecked("") {
+                return Err(ContractError::Unauthorized {});
+            }
+
+            let init_response = parse_instantiate_response_data(data.as_slice())
+                .map_err(|e| StdError::generic_err(format!("{e}")))?;
+
+            config.pair_info.liquidity_token =
+                deps.api.addr_validate(&init_response.contract_address)?;
+
+            CONFIG.save(deps.storage, &config)?;
+
+            Ok(Response::new()
+                .add_attribute("liquidity_token_addr", config.pair_info.liquidity_token))
+        }
+        _ => Err(ContractError::FailedToParseReply {}),
+    }
+}
+
+/// Exposes all the execute functions available in the contract.
+///
+/// ## Variants
+/// * **ExecuteMsg::UpdateConfig { params: Binary }** Not supported.
+///
+/// * **ExecuteMsg::Receive(msg)** Receives a message of type [`Cw20ReceiveMsg`] and processes
+/// it depending on the received template.
+///
+/// * **ExecuteMsg::ProvideLiquidity {
+///             assets,
+///             slippage_tolerance,
+///             auto_stake,
+///             receiver,
+///         }** Provides liquidity in the pair with the specified input parameters.
+///
+/// * **ExecuteMsg::Swap {
+///             offer_asset,
+///             belief_price,
+///             max_spread,
+///             to,
+///         }** Performs a swap operation with the specified parameters.
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Receive(msg) => receive_cw20(deps, env, info, msg),
+        ExecuteMsg::ProvideLiquidity {
+            assets,
+            slippage_tolerance,
+            auto_stake,
+            receiver,
+        } => provide_liquidity(
+            deps,
+            env,
+            info,
+            assets,
+            slippage_tolerance,
+            auto_stake,
+            receiver,
+        ),
+        ExecuteMsg::Swap {
+            offer_asset,
+            belief_price,
+            max_spread,
+            to,
+            ..
+        } => {
+            offer_asset.info.check(deps.api)?;
+            if !offer_asset.is_native_token() {
+                return Err(ContractError::Cw20DirectSwap {});
+            }
+
+            let to_addr = addr_opt_validate(deps.api, &to)?;
+
+            swap(
+                deps,
+                env,
+                info.clone(),
+                info.sender,
+                offer_asset,
+                belief_price,
+                max_spread,
+                to_addr,
+            )
+        }
+        ExecuteMsg::UpdateConfig { params } => update_config(deps, env, info, params),
+        _ => Err(ContractError::NonSupported {}),
+    }
+}
+
+/// Receives a message of type [`Cw20ReceiveMsg`] and processes it depending on the received template.
+///
+/// * **cw20_msg** is the CW20 message that has to be processed.
+pub fn receive_cw20(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    cw20_msg: Cw20ReceiveMsg,
+) -> Result<Response, ContractError> {
+    match from_binary(&cw20_msg.msg)? {
+        Cw20HookMsg::Swap {
+            belief_price,
+            max_spread,
+            to,
+            ..
+        } => {
+            // Only asset contract can execute this message
+            let mut authorized = false;
+            let config = CONFIG.load(deps.storage)?;
+
+            for pool in config.pair_info.asset_infos {
+                if let AssetInfo::Token { contract_addr, .. } = &pool {
+                    if contract_addr == info.sender {
+                        authorized = true;
+                    }
+                }
+            }
+
+            if !authorized {
+                return Err(ContractError::Unauthorized {});
+            }
+
+            let to_addr = addr_opt_validate(deps.api, &to)?;
+            let contract_addr = info.sender.clone();
+
+            swap(
+                deps,
+                env,
+                info,
+                Addr::unchecked(cw20_msg.sender),
+                Asset {
+                    info: AssetInfo::Token { contract_addr },
+                    amount: cw20_msg.amount,
+                },
+                belief_price,
+                max_spread,
+                to_addr,
+            )
+        }
+        Cw20HookMsg::WithdrawLiquidity { assets } => withdraw_liquidity(
+            deps,
+            env,
+            info,
+            Addr::unchecked(cw20_msg.sender),
+            cw20_msg.amount,
+            assets,
+        ),
+    }
+}
+
+/// Provides liquidity in the pair with the specified input parameters.
+///
+/// * **assets** is an array with assets available in the pool.
+///
+/// * **slippage_tolerance** is an optional parameter which is used to specify how much
+/// the pool price can move until the provide liquidity transaction goes through.
+///
+/// * **auto_stake** is an optional parameter which determines whether the LP tokens minted after
+/// liquidity provision are automatically staked in the Generator contract on behalf of the LP token receiver.
+///
+/// * **receiver** is an optional parameter which defines the receiver of the LP tokens.
+/// If no custom receiver is specified, the pair will mint LP tokens for the function caller.
+///
+/// NOTE - the address that wants to provide liquidity should approve the pair contract to pull its relevant tokens.
+pub fn provide_liquidity(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    assets: Vec<Asset>,
+    slippage_tolerance: Option<Decimal>,
+    auto_stake: Option<bool>,
+    receiver: Option<String>,
+) -> Result<Response, ContractError> {
+    if assets.len() != 2 {
+        return Err(StdError::generic_err("asset_infos must contain exactly two elements").into());
+    }
+    assets[0].info.check(deps.api)?;
+    assets[1].info.check(deps.api)?;
+
+    let auto_stake = auto_stake.unwrap_or(false);
+
+    let mut config = CONFIG.load(deps.storage)?;
+    info.funds
+        .assert_coins_properly_sent(&assets, &config.pair_info.asset_infos)?;
+    let mut pools = config
+        .pair_info
+        .query_pools(&deps.querier, &config.pair_info.contract_addr)?;
+    let deposits = [
+        assets
+            .iter()
+            .find(|a| a.info.equal(&pools[0].info))
+            .map(|a| a.amount)
+            .expect("Wrong asset info is given"),
+        assets
+            .iter()
+            .find(|a| a.info.equal(&pools[1].info))
+            .map(|a| a.amount)
+            .expect("Wrong asset info is given"),
+    ];
+
+    if deposits[0].is_zero() || deposits[1].is_zero() {
+        return Err(ContractError::InvalidZeroAmount {});
+    }
+
+    let mut messages = vec![];
+    for (i, pool) in pools.iter_mut().enumerate() {
+        // If the asset is a token contract, then we need to execute a TransferFrom msg to receive assets
+        if let AssetInfo::Token { contract_addr, .. } = &pool.info {
+            messages.push(CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: contract_addr.to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::TransferFrom {
+                    owner: info.sender.to_string(),
+                    recipient: env.contract.address.to_string(),
+                    amount: deposits[i],
+                })?,
+                funds: vec![],
+            }));
+        } else {
+            // If the asset is native token, the pool balance is already increased
+            // To calculate the total amount of deposits properly, we should subtract the user deposit from the pool
+            pool.amount = pool.amount.checked_sub(deposits[i])?;
+        }
+    }
+
+    let total_share = query_supply(&deps.querier, &config.pair_info.liquidity_token)?;
+    let share = if total_share.is_zero() {
+        // Initial share = collateral amount
+        let share = Uint128::new(
+            (U256::from(deposits[0].u128()) * U256::from(deposits[1].u128()))
+                .integer_sqrt()
+                .as_u128(),
+        )
+        .checked_sub(MINIMUM_LIQUIDITY_AMOUNT)
+        .map_err(|_| ContractError::MinimumLiquidityAmountError {})?;
+
+        messages.extend(mint_liquidity_token_message(
+            deps.querier,
+            &config,
+            &env.contract.address,
+            &env.contract.address,
+            MINIMUM_LIQUIDITY_AMOUNT,
+            false,
+        )?);
+
+        // share cannot become zero after minimum liquidity subtraction
+        if share.is_zero() {
+            return Err(ContractError::MinimumLiquidityAmountError {});
+        }
+
+        share
+    } else {
+        // Assert slippage tolerance
+        assert_slippage_tolerance(slippage_tolerance, &deposits, &pools)?;
+
+        // min(1, 2)
+        // 1. sqrt(deposit_0 * exchange_rate_0_to_1 * deposit_0) * (total_share / sqrt(pool_0 * pool_0))
+        // == deposit_0 * total_share / pool_0
+        // 2. sqrt(deposit_1 * exchange_rate_1_to_0 * deposit_1) * (total_share / sqrt(pool_1 * pool_1))
+        // == deposit_1 * total_share / pool_1
+        std::cmp::min(
+            deposits[0].multiply_ratio(total_share, pools[0].amount),
+            deposits[1].multiply_ratio(total_share, pools[1].amount),
+        )
+    };
+
+    // Mint LP tokens for the sender or for the receiver (if set)
+    let receiver = addr_opt_validate(deps.api, &receiver)?.unwrap_or_else(|| info.sender.clone());
+    messages.extend(mint_liquidity_token_message(
+        deps.querier,
+        &config,
+        &env.contract.address,
+        &receiver,
+        share,
+        auto_stake,
+    )?);
+
+    if config.track_asset_balances {
+        for (i, pool) in pools.iter().enumerate() {
+            BALANCES.save(
+                deps.storage,
+                &pool.info,
+                &pool.amount.checked_add(deposits[i])?,
+                env.block.height,
+            )?;
+        }
+    }
+
+    // Accumulate prices for the assets in the pool
+    if let Some((price0_cumulative_new, price1_cumulative_new, block_time)) =
+        accumulate_prices(env, &config, pools[0].amount, pools[1].amount)?
+    {
+        config.price0_cumulative_last = price0_cumulative_new;
+        config.price1_cumulative_last = price1_cumulative_new;
+        config.block_time_last = block_time;
+        CONFIG.save(deps.storage, &config)?;
+    }
+
+    Ok(Response::new().add_messages(messages).add_attributes(vec![
+        attr("action", "provide_liquidity"),
+        attr("sender", info.sender),
+        attr("receiver", receiver),
+        attr("assets", format!("{}, {}", assets[0], assets[1])),
+        attr("share", share),
+    ]))
+}
+
+/// Mint LP tokens for a beneficiary and auto stake the tokens in the Generator contract (if auto staking is specified).
+///
+/// * **recipient** is the LP token recipient.
+///
+/// * **amount** is the amount of LP tokens that will be minted for the recipient.
+///
+/// * **auto_stake** determines whether the newly minted LP tokens will
+/// be automatically staked in the Generator on behalf of the recipient.
+fn mint_liquidity_token_message(
+    querier: QuerierWrapper,
+    config: &Config,
+    contract_address: &Addr,
+    recipient: &Addr,
+    amount: Uint128,
+    auto_stake: bool,
+) -> Result<Vec<CosmosMsg>, ContractError> {
+    let lp_token = &config.pair_info.liquidity_token;
+
+    // If no auto-stake - just mint to recipient
+    if !auto_stake {
+        return Ok(vec![CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: lp_token.to_string(),
+            msg: to_binary(&Cw20ExecuteMsg::Mint {
+                recipient: recipient.to_string(),
+                amount,
+            })?,
+            funds: vec![],
+        })]);
+    }
+
+    // Mint for the pair contract and stake into the Generator contract
+    let generator = query_factory_config(&querier, &config.factory_addr)?.generator_address;
+
+    if let Some(generator) = generator {
+        Ok(vec![
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: lp_token.to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::Mint {
+                    recipient: contract_address.to_string(),
+                    amount,
+                })?,
+                funds: vec![],
+            }),
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: lp_token.to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::Send {
+                    contract: generator.to_string(),
+                    amount,
+                    msg: to_binary(&GeneratorHookMsg::DepositFor(recipient.to_string()))?,
+                })?,
+                funds: vec![],
+            }),
+        ])
+    } else {
+        Err(ContractError::AutoStakeError {})
+    }
+}
+
+/// Withdraw liquidity from the pool.
+/// * **sender** is the address that will receive assets back from the pair contract.
+///
+/// * **amount** is the amount of LP tokens to burn.
+pub fn withdraw_liquidity(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    sender: Addr,
+    amount: Uint128,
+    assets: Vec<Asset>,
+) -> Result<Response, ContractError> {
+    let mut config = CONFIG.load(deps.storage).unwrap();
+
+    if info.sender != config.pair_info.liquidity_token {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    let (pools, total_share) = pool_info(deps.querier, &config)?;
+
+    let refund_assets = if assets.is_empty() {
+        // Usual withdraw (balanced)
+        get_share_in_assets(&pools, amount, total_share)
+    } else {
+        return Err(StdError::generic_err("Imbalanced withdraw is currently disabled").into());
+    };
+
+    if config.track_asset_balances {
+        for (i, pool) in pools.iter().enumerate() {
+            BALANCES.save(
+                deps.storage,
+                &pool.info,
+                &(pool.amount - refund_assets[i].amount),
+                env.block.height,
+            )?;
+        }
+    }
+
+    // Accumulate prices for the pair assets
+    if let Some((price0_cumulative_new, price1_cumulative_new, block_time)) =
+        accumulate_prices(env, &config, pools[0].amount, pools[1].amount)?
+    {
+        config.price0_cumulative_last = price0_cumulative_new;
+        config.price1_cumulative_last = price1_cumulative_new;
+        config.block_time_last = block_time;
+        CONFIG.save(deps.storage, &config)?;
+    }
+
+    // Update the pool info
+    let messages: Vec<CosmosMsg> = vec![
+        refund_assets[0].clone().into_msg(sender.clone())?,
+        refund_assets[1].clone().into_msg(sender.clone())?,
+        CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: config.pair_info.liquidity_token.to_string(),
+            msg: to_binary(&Cw20ExecuteMsg::Burn { amount })?,
+            funds: vec![],
+        }),
+    ];
+
+    Ok(Response::new().add_messages(messages).add_attributes(vec![
+        attr("action", "withdraw_liquidity"),
+        attr("sender", sender),
+        attr("withdrawn_share", amount),
+        attr(
+            "refund_assets",
+            format!("{}, {}", refund_assets[0], refund_assets[1]),
+        ),
+    ]))
+}
+
+/// Returns the amount of pool assets that correspond to an amount of LP tokens.
+///
+/// * **pools** is the array with assets in the pool.
+///
+/// * **amount** is amount of LP tokens to compute a corresponding amount of assets for.
+///
+/// * **total_share** is the total amount of LP tokens currently minted.
+pub fn get_share_in_assets(pools: &[Asset], amount: Uint128, total_share: Uint128) -> Vec<Asset> {
+    let mut share_ratio = Decimal::zero();
+    if !total_share.is_zero() {
+        share_ratio = Decimal::from_ratio(amount, total_share);
+    }
+
+    pools
+        .iter()
+        .map(|a| Asset {
+            info: a.info.clone(),
+            amount: a.amount * share_ratio,
+        })
+        .collect()
+}
+
+/// Performs an swap operation with the specified parameters. The trader must approve the
+/// pool contract to transfer offer assets from their wallet.
+///
+/// * **sender** is the sender of the swap operation.
+///
+/// * **offer_asset** proposed asset for swapping.
+///
+/// * **belief_price** is used to calculate the maximum swap spread.
+///
+/// * **max_spread** sets the maximum spread of the swap operation.
+///
+/// * **to** sets the recipient of the swap operation.
+///
+/// NOTE - the address that wants to swap should approve the pair contract to pull the offer token.
+#[allow(clippy::too_many_arguments)]
+pub fn swap(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    sender: Addr,
+    offer_asset: Asset,
+    belief_price: Option<Decimal>,
+    max_spread: Option<Decimal>,
+    to: Option<Addr>,
+) -> Result<Response, ContractError> {
+    offer_asset.assert_sent_native_token_balance(&info)?;
+
+    let mut config = CONFIG.load(deps.storage)?;
+
+    // If the asset balance is already increased, we should subtract the user deposit from the pool amount
+    let pools = config
+        .pair_info
+        .query_pools(&deps.querier, &config.pair_info.contract_addr)?
+        .into_iter()
+        .map(|mut p| {
+            if p.info.equal(&offer_asset.info) {
+                p.amount = p.amount.checked_sub(offer_asset.amount)?;
+            }
+            Ok(p)
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let offer_pool: Asset;
+    let ask_pool: Asset;
+
+    if offer_asset.info.equal(&pools[0].info) {
+        offer_pool = pools[0].clone();
+        ask_pool = pools[1].clone();
+    } else if offer_asset.info.equal(&pools[1].info) {
+        offer_pool = pools[1].clone();
+        ask_pool = pools[0].clone();
+    } else {
+        return Err(ContractError::AssetMismatch {});
+    }
+
+    // Get fee info from the factory
+    let fee_info = query_fee_info(
+        &deps.querier,
+        &config.factory_addr,
+        config.pair_info.pair_type.clone(),
+    )?;
+
+    let offer_amount = offer_asset.amount;
+
+    let (return_amount, spread_amount, commission_amount) = compute_swap(
+        offer_pool.amount,
+        ask_pool.amount,
+        offer_amount,
+        fee_info.total_fee_rate,
+    )?;
+
+    // Check the max spread limit (if it was specified)
+    assert_max_spread(
+        belief_price,
+        max_spread,
+        offer_amount,
+        return_amount + commission_amount,
+        spread_amount,
+    )?;
+
+    let return_asset = Asset {
+        info: ask_pool.info.clone(),
+        amount: return_amount,
+    };
+
+    let receiver = to.unwrap_or_else(|| sender.clone());
+    let mut messages = vec![];
+    if !return_amount.is_zero() {
+        messages.push(return_asset.into_msg(receiver.clone())?)
+    }
+
+    // Compute the Maker fee
+    let mut maker_fee_amount = Uint128::zero();
+    if let Some(fee_address) = fee_info.fee_address {
+        if let Some(f) =
+            calculate_maker_fee(&ask_pool.info, commission_amount, fee_info.maker_fee_rate)
+        {
+            maker_fee_amount = f.amount;
+            messages.push(f.into_msg(fee_address)?);
+        }
+    }
+
+    if config.track_asset_balances {
+        BALANCES.save(
+            deps.storage,
+            &offer_pool.info,
+            &(offer_pool.amount + offer_amount),
+            env.block.height,
+        )?;
+        BALANCES.save(
+            deps.storage,
+            &ask_pool.info,
+            &(ask_pool.amount - return_amount - maker_fee_amount),
+            env.block.height,
+        )?;
+    }
+
+    // Accumulate prices for the assets in the pool
+    if let Some((price0_cumulative_new, price1_cumulative_new, block_time)) =
+        accumulate_prices(env, &config, pools[0].amount, pools[1].amount)?
+    {
+        config.price0_cumulative_last = price0_cumulative_new;
+        config.price1_cumulative_last = price1_cumulative_new;
+        config.block_time_last = block_time;
+        CONFIG.save(deps.storage, &config)?;
+    }
+
+    Ok(Response::new()
+        .add_messages(
+            // 1. send collateral tokens from the contract to a user
+            // 2. send inactive commission fees to the Maker contract
+            messages,
+        )
+        .add_attributes(vec![
+            attr("action", "swap"),
+            attr("sender", sender),
+            attr("receiver", receiver),
+            attr("offer_asset", offer_asset.info.to_string()),
+            attr("ask_asset", ask_pool.info.to_string()),
+            attr("offer_amount", offer_amount),
+            attr("return_amount", return_amount),
+            attr("spread_amount", spread_amount),
+            attr("commission_amount", commission_amount),
+            attr("maker_fee_amount", maker_fee_amount),
+        ]))
+}
+
+/// Updates the pool configuration with the specified parameters in the `params` variable.
+///
+/// * **params** new parameter values.
+pub fn update_config(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    params: Binary,
+) -> Result<Response, ContractError> {
+    let mut config = CONFIG.load(deps.storage)?;
+    let factory_config = query_factory_config(&deps.querier, &config.factory_addr)?;
+
+    if info.sender != factory_config.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    let mut response = Response::default();
+
+    match from_binary::<XYKPoolUpdateParams>(&params)? {
+        XYKPoolUpdateParams::EnableAssetBalancesTracking => {
+            if config.track_asset_balances {
+                return Err(ContractError::AssetBalancesTrackingIsAlreadyEnabled {});
+            }
+            config.track_asset_balances = true;
+
+            let pools = config
+                .pair_info
+                .query_pools(&deps.querier, &config.pair_info.contract_addr)?;
+
+            for pool in pools.iter() {
+                BALANCES.save(deps.storage, &pool.info, &pool.amount, env.block.height)?;
+            }
+
+            CONFIG.save(deps.storage, &config)?;
+
+            response.attributes.push(attr(
+                "asset_balances_tracking".to_owned(),
+                "enabled".to_owned(),
+            ));
+        }
+    }
+
+    Ok(response)
+}
+
+/// Accumulate token prices for the assets in the pool.
+/// Note that this function shifts **block_time** when any of the token prices is zero in order to not
+/// fill an accumulator with a null price for that period.
+///
+/// * **x** is the balance of asset\[\0] in the pool.
+///
+/// * **y** is the balance of asset\[\1] in the pool.
+pub fn accumulate_prices(
+    env: Env,
+    config: &Config,
+    x: Uint128,
+    y: Uint128,
+) -> StdResult<Option<(Uint128, Uint128, u64)>> {
+    let block_time = env.block.time.seconds();
+    if block_time <= config.block_time_last {
+        return Ok(None);
+    }
+
+    // We have to shift block_time when any price is zero in order to not fill an accumulator with a null price for that period
+    let time_elapsed = Uint128::from(block_time - config.block_time_last);
+
+    let mut pcl0 = config.price0_cumulative_last;
+    let mut pcl1 = config.price1_cumulative_last;
+
+    if !x.is_zero() && !y.is_zero() {
+        let price_precision = Uint128::from(10u128.pow(TWAP_PRECISION.into()));
+        pcl0 = config.price0_cumulative_last.wrapping_add(
+            time_elapsed
+                .checked_mul(price_precision)?
+                .multiply_ratio(y, x),
+        );
+        pcl1 = config.price1_cumulative_last.wrapping_add(
+            time_elapsed
+                .checked_mul(price_precision)?
+                .multiply_ratio(x, y),
+        );
+    };
+
+    Ok(Some((pcl0, pcl1, block_time)))
+}
+
+/// Calculates the amount of fees the Maker contract gets according to specified pair parameters.
+/// Returns a [`None`] if the Maker fee is zero, otherwise returns a [`Asset`] struct with the specified attributes.
+///
+/// * **pool_info** contains information about the pool asset for which the commission will be calculated.
+///
+/// * **commission_amount** is the total amount of fees charged for a swap.
+///
+/// * **maker_commission_rate** is the percentage of fees that go to the Maker contract.
+pub fn calculate_maker_fee(
+    pool_info: &AssetInfo,
+    commission_amount: Uint128,
+    maker_commission_rate: Decimal,
+) -> Option<Asset> {
+    let maker_fee: Uint128 = commission_amount * maker_commission_rate;
+    if maker_fee.is_zero() {
+        return None;
+    }
+
+    Some(Asset {
+        info: pool_info.clone(),
+        amount: maker_fee,
+    })
+}
+
+/// Exposes all the queries available in the contract.
+///
+/// ## Queries
+/// * **QueryMsg::Pair {}** Returns information about the pair in an object of type [`PairInfo`].
+///
+/// * **QueryMsg::Pool {}** Returns information about the amount of assets in the pair contract as
+/// well as the amount of LP tokens issued using an object of type [`PoolResponse`].
+///
+/// * **QueryMsg::Share { amount }** Returns the amount of assets that could be withdrawn from the pool
+/// using a specific amount of LP tokens. The result is returned in a vector that contains objects of type [`Asset`].
+///
+/// * **QueryMsg::Simulation { offer_asset }** Returns the result of a swap simulation using a [`SimulationResponse`] object.
+///
+/// * **QueryMsg::ReverseSimulation { ask_asset }** Returns the result of a reverse swap simulation  using
+/// a [`ReverseSimulationResponse`] object.
+///
+/// * **QueryMsg::CumulativePrices {}** Returns information about cumulative prices for the assets in the
+/// pool using a [`CumulativePricesResponse`] object.
+///
+/// * **QueryMsg::Config {}** Returns the configuration for the pair contract using a [`ConfigResponse`] object.
+///
+/// * **QueryMsg::AssetBalanceAt { asset_info, block_height }** Returns the balance of the specified asset that was in the pool
+/// just preceeding the moment of the specified block height creation.
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Pair {} => to_binary(&CONFIG.load(deps.storage)?.pair_info),
+        QueryMsg::Pool {} => to_binary(&query_pool(deps)?),
+        QueryMsg::Share { amount } => to_binary(&query_share(deps, amount)?),
+        QueryMsg::Simulation { offer_asset, .. } => {
+            to_binary(&query_simulation(deps, offer_asset)?)
+        }
+        QueryMsg::ReverseSimulation { ask_asset, .. } => {
+            to_binary(&query_reverse_simulation(deps, ask_asset)?)
+        }
+        QueryMsg::CumulativePrices {} => to_binary(&query_cumulative_prices(deps, env)?),
+        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::AssetBalanceAt {
+            asset_info,
+            block_height,
+        } => to_binary(&query_asset_balances_at(deps, asset_info, block_height)?),
+        _ => Err(StdError::generic_err("Query is not supported")),
+    }
+}
+
+/// Returns the amounts of assets in the pair contract as well as the amount of LP
+/// tokens currently minted in an object of type [`PoolResponse`].
+pub fn query_pool(deps: Deps) -> StdResult<PoolResponse> {
+    let config = CONFIG.load(deps.storage)?;
+    let (assets, total_share) = pool_info(deps.querier, &config)?;
+
+    let resp = PoolResponse {
+        assets,
+        total_share,
+    };
+
+    Ok(resp)
+}
+
+/// Returns the amount of assets that could be withdrawn from the pool using a specific amount of LP tokens.
+/// The result is returned in a vector that contains objects of type [`Asset`].
+///
+/// * **amount** is the amount of LP tokens for which we calculate associated amounts of assets.
+pub fn query_share(deps: Deps, amount: Uint128) -> StdResult<Vec<Asset>> {
+    let config = CONFIG.load(deps.storage)?;
+    let (pools, total_share) = pool_info(deps.querier, &config)?;
+    let refund_assets = get_share_in_assets(&pools, amount, total_share);
+
+    Ok(refund_assets)
+}
+
+/// Returns information about a swap simulation in a [`SimulationResponse`] object.
+///
+/// * **offer_asset** is the asset to swap as well as an amount of the said asset.
+pub fn query_simulation(deps: Deps, offer_asset: Asset) -> StdResult<SimulationResponse> {
+    let config = CONFIG.load(deps.storage)?;
+
+    let pools = config
+        .pair_info
+        .query_pools(&deps.querier, &config.pair_info.contract_addr)?;
+
+    let offer_pool: Asset;
+    let ask_pool: Asset;
+    if offer_asset.info.equal(&pools[0].info) {
+        offer_pool = pools[0].clone();
+        ask_pool = pools[1].clone();
+    } else if offer_asset.info.equal(&pools[1].info) {
+        offer_pool = pools[1].clone();
+        ask_pool = pools[0].clone();
+    } else {
+        return Err(StdError::generic_err(
+            "Given offer asset does not belong in the pair",
+        ));
+    }
+
+    // Get fee info from the factory contract
+    let fee_info = query_fee_info(
+        &deps.querier,
+        config.factory_addr,
+        config.pair_info.pair_type,
+    )?;
+
+    let (return_amount, spread_amount, commission_amount) = compute_swap(
+        offer_pool.amount,
+        ask_pool.amount,
+        offer_asset.amount,
+        fee_info.total_fee_rate,
+    )?;
+
+    Ok(SimulationResponse {
+        return_amount,
+        spread_amount,
+        commission_amount,
+    })
+}
+
+/// Returns information about a reverse swap simulation in a [`ReverseSimulationResponse`] object.
+///
+/// * **ask_asset** is the asset to swap to as well as the desired amount of ask
+/// assets to receive from the swap.
+pub fn query_reverse_simulation(
+    deps: Deps,
+    ask_asset: Asset,
+) -> StdResult<ReverseSimulationResponse> {
+    let config = CONFIG.load(deps.storage)?;
+
+    let pools = config
+        .pair_info
+        .query_pools(&deps.querier, &config.pair_info.contract_addr)?;
+
+    let offer_pool: Asset;
+    let ask_pool: Asset;
+    if ask_asset.info.equal(&pools[0].info) {
+        ask_pool = pools[0].clone();
+        offer_pool = pools[1].clone();
+    } else if ask_asset.info.equal(&pools[1].info) {
+        ask_pool = pools[1].clone();
+        offer_pool = pools[0].clone();
+    } else {
+        return Err(StdError::generic_err(
+            "Given ask asset doesn't belong to pairs",
+        ));
+    }
+
+    // Get fee info from factory
+    let fee_info = query_fee_info(
+        &deps.querier,
+        config.factory_addr,
+        config.pair_info.pair_type,
+    )?;
+
+    let (offer_amount, spread_amount, commission_amount) = compute_offer_amount(
+        offer_pool.amount,
+        ask_pool.amount,
+        ask_asset.amount,
+        fee_info.total_fee_rate,
+    )?;
+
+    Ok(ReverseSimulationResponse {
+        offer_amount,
+        spread_amount,
+        commission_amount,
+    })
+}
+
+/// Returns information about cumulative prices for the assets in the pool using a [`CumulativePricesResponse`] object.
+pub fn query_cumulative_prices(deps: Deps, env: Env) -> StdResult<CumulativePricesResponse> {
+    let config = CONFIG.load(deps.storage)?;
+    let (assets, total_share) = pool_info(deps.querier, &config)?;
+
+    let mut price0_cumulative_last = config.price0_cumulative_last;
+    let mut price1_cumulative_last = config.price1_cumulative_last;
+
+    if let Some((price0_cumulative_new, price1_cumulative_new, _)) =
+        accumulate_prices(env, &config, assets[0].amount, assets[1].amount)?
+    {
+        price0_cumulative_last = price0_cumulative_new;
+        price1_cumulative_last = price1_cumulative_new;
+    }
+
+    let cumulative_prices = vec![
+        (
+            assets[0].info.clone(),
+            assets[1].info.clone(),
+            price0_cumulative_last,
+        ),
+        (
+            assets[1].info.clone(),
+            assets[0].info.clone(),
+            price1_cumulative_last,
+        ),
+    ];
+
+    let resp = CumulativePricesResponse {
+        assets,
+        total_share,
+        cumulative_prices,
+    };
+
+    Ok(resp)
+}
+
+/// Returns the pair contract configuration in a [`ConfigResponse`] object.
+pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+    let config: Config = CONFIG.load(deps.storage)?;
+
+    let factory_config = query_factory_config(&deps.querier, &config.factory_addr)?;
+
+    Ok(ConfigResponse {
+        block_time_last: config.block_time_last,
+        params: Some(to_binary(&XYKPoolConfig {
+            track_asset_balances: config.track_asset_balances,
+        })?),
+        owner: factory_config.owner,
+        factory_addr: config.factory_addr,
+    })
+}
+
+/// Returns the balance of the specified asset that was in the pool
+/// just preceeding the moment of the specified block height creation.
+/// It will return None (null) if the balance was not tracked up to the specified block height
+pub fn query_asset_balances_at(
+    deps: Deps,
+    asset_info: AssetInfo,
+    block_height: Uint64,
+) -> StdResult<Option<Uint128>> {
+    BALANCES.may_load_at_height(deps.storage, &asset_info, block_height.u64())
+}
+
+/// Returns the result of a swap.
+///
+/// * **offer_pool** total amount of offer assets in the pool.
+///
+/// * **ask_pool** total amount of ask assets in the pool.
+///
+/// * **offer_amount** amount of offer assets to swap.
+///
+/// * **commission_rate** total amount of fees charged for the swap.
+pub fn compute_swap(
+    offer_pool: Uint128,
+    ask_pool: Uint128,
+    offer_amount: Uint128,
+    commission_rate: Decimal,
+) -> StdResult<(Uint128, Uint128, Uint128)> {
+    // offer => ask
+    check_swap_parameters(vec![offer_pool, ask_pool], offer_amount)?;
+
+    let offer_pool: Uint256 = offer_pool.into();
+    let ask_pool: Uint256 = ask_pool.into();
+    let offer_amount: Uint256 = offer_amount.into();
+    let commission_rate = Decimal256::from(commission_rate);
+
+    // ask_amount = (ask_pool - cp / (offer_pool + offer_amount))
+    let cp: Uint256 = offer_pool * ask_pool;
+    let return_amount: Uint256 = (Decimal256::from_ratio(ask_pool, 1u8)
+        - Decimal256::from_ratio(cp, offer_pool + offer_amount))
+        * Uint256::from(1u8);
+
+    // Calculate spread & commission
+    let spread_amount: Uint256 =
+        (offer_amount * Decimal256::from_ratio(ask_pool, offer_pool)).saturating_sub(return_amount);
+    let commission_amount: Uint256 = return_amount * commission_rate;
+
+    // The commision (minus the part that goes to the Maker contract) will be absorbed by the pool
+    let return_amount: Uint256 = return_amount - commission_amount;
+    Ok((
+        return_amount.try_into()?,
+        spread_amount.try_into()?,
+        commission_amount.try_into()?,
+    ))
+}
+
+/// Returns an amount of offer assets for a specified amount of ask assets.
+///
+/// * **offer_pool** total amount of offer assets in the pool.
+///
+/// * **ask_pool** total amount of ask assets in the pool.
+///
+/// * **ask_amount** amount of ask assets to swap to.
+///
+/// * **commission_rate** total amount of fees charged for the swap.
+pub fn compute_offer_amount(
+    offer_pool: Uint128,
+    ask_pool: Uint128,
+    ask_amount: Uint128,
+    commission_rate: Decimal,
+) -> StdResult<(Uint128, Uint128, Uint128)> {
+    // ask => offer
+    check_swap_parameters(vec![offer_pool, ask_pool], ask_amount)?;
+
+    // offer_amount = cp / (ask_pool - ask_amount / (1 - commission_rate)) - offer_pool
+    let cp = Uint256::from(offer_pool) * Uint256::from(ask_pool);
+    let one_minus_commission = Decimal256::one() - Decimal256::from(commission_rate);
+    let inv_one_minus_commission = Decimal256::one() / one_minus_commission;
+
+    let offer_amount: Uint128 = cp
+        .multiply_ratio(
+            Uint256::from(1u8),
+            Uint256::from(
+                ask_pool.checked_sub(
+                    (Uint256::from(ask_amount) * inv_one_minus_commission).try_into()?,
+                )?,
+            ),
+        )
+        .checked_sub(offer_pool.into())?
+        .try_into()?;
+
+    let before_commission_deduction = Uint256::from(ask_amount) * inv_one_minus_commission;
+    let spread_amount = (offer_amount * Decimal::from_ratio(ask_pool, offer_pool))
+        .saturating_sub(before_commission_deduction.try_into()?);
+    let commission_amount = before_commission_deduction * Decimal256::from(commission_rate);
+    Ok((offer_amount, spread_amount, commission_amount.try_into()?))
+}
+
+/// If `belief_price` and `max_spread` are both specified, we compute a new spread,
+/// otherwise we just use the swap spread to check `max_spread`.
+///
+/// * **belief_price** belief price used in the swap.
+///
+/// * **max_spread** max spread allowed so that the swap can be executed successfully.
+///
+/// * **offer_amount** amount of assets to swap.
+///
+/// * **return_amount** amount of assets to receive from the swap.
+///
+/// * **spread_amount** spread used in the swap.
+pub fn assert_max_spread(
+    belief_price: Option<Decimal>,
+    max_spread: Option<Decimal>,
+    offer_amount: Uint128,
+    return_amount: Uint128,
+    spread_amount: Uint128,
+) -> Result<(), ContractError> {
+    let default_spread = Decimal::from_str(DEFAULT_SLIPPAGE)?;
+    let max_allowed_spread = Decimal::from_str(MAX_ALLOWED_SLIPPAGE)?;
+
+    let max_spread = max_spread.unwrap_or(default_spread);
+    if max_spread.gt(&max_allowed_spread) {
+        return Err(ContractError::AllowedSpreadAssertion {});
+    }
+
+    if let Some(belief_price) = belief_price {
+        let expected_return = offer_amount
+            * belief_price
+                .inv()
+                .ok_or_else(|| StdError::generic_err("Belief price must not be zero!"))?;
+        let spread_amount = expected_return.saturating_sub(return_amount);
+
+        if return_amount < expected_return
+            && Decimal::from_ratio(spread_amount, expected_return) > max_spread
+        {
+            return Err(ContractError::MaxSpreadAssertion {});
+        }
+    } else if Decimal::from_ratio(spread_amount, return_amount + spread_amount) > max_spread {
+        return Err(ContractError::MaxSpreadAssertion {});
+    }
+
+    Ok(())
+}
+
+/// This is an internal function that enforces slippage tolerance for swaps.
+///
+/// * **slippage_tolerance** slippage tolerance to enforce.
+///
+/// * **deposits** array with offer and ask amounts for a swap.
+///
+/// * **pools** array with total amount of assets in the pool.
+pub fn assert_slippage_tolerance(
+    slippage_tolerance: Option<Decimal>,
+    deposits: &[Uint128; 2],
+    pools: &[Asset],
+) -> Result<(), ContractError> {
+    let default_slippage = Decimal::from_str(DEFAULT_SLIPPAGE)?;
+    let max_allowed_slippage = Decimal::from_str(MAX_ALLOWED_SLIPPAGE)?;
+
+    let slippage_tolerance = slippage_tolerance.unwrap_or(default_slippage);
+    if slippage_tolerance.gt(&max_allowed_slippage) {
+        return Err(ContractError::AllowedSpreadAssertion {});
+    }
+
+    let slippage_tolerance: Decimal256 = Decimal256::from(slippage_tolerance);
+    let one_minus_slippage_tolerance = Decimal256::one() - slippage_tolerance;
+    let deposits: [Uint256; 2] = [deposits[0].into(), deposits[1].into()];
+    let pools: [Uint256; 2] = [pools[0].amount.into(), pools[1].amount.into()];
+
+    // Ensure each price does not change more than what the slippage tolerance allows
+    if Decimal256::from_ratio(deposits[0], deposits[1]) * one_minus_slippage_tolerance
+        > Decimal256::from_ratio(pools[0], pools[1])
+        || Decimal256::from_ratio(deposits[1], deposits[0]) * one_minus_slippage_tolerance
+            > Decimal256::from_ratio(pools[1], pools[0])
+    {
+        return Err(ContractError::MaxSlippageAssertion {});
+    }
+
+    Ok(())
+}
+
+/// Manages the contract migration.
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    Ok(Response::default())
+}
+
+/// Returns the total amount of assets in the pool as well as the total amount of LP tokens currently minted.
+pub fn pool_info(querier: QuerierWrapper, config: &Config) -> StdResult<(Vec<Asset>, Uint128)> {
+    let pools = config
+        .pair_info
+        .query_pools(&querier, &config.pair_info.contract_addr)?;
+    let total_share = query_supply(&querier, &config.pair_info.liquidity_token)?;
+
+    Ok((pools, total_share))
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{Decimal, Uint128};
+
+    use crate::contract::compute_swap;
+
+    #[test]
+    fn compute_swap_does_not_panic_on_spread_calc() {
+        let offer_pool = Uint128::from(u128::MAX / 2);
+        let ask_pool = Uint128::from(u128::MAX / 1000000000);
+        let offer_amount = Uint128::from(1000000000u128);
+        let commission_rate = Decimal::permille(3);
+
+        let (return_amount, spread_amount, commission_amount) =
+            compute_swap(offer_pool, ask_pool, offer_amount, commission_rate).unwrap();
+        assert_eq!(return_amount, Uint128::from(2u128));
+        assert_eq!(spread_amount, Uint128::zero());
+        assert_eq!(commission_amount, Uint128::zero());
+    }
+}

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -69,7 +69,7 @@ pub fn instantiate(
             contract_addr: env.contract.address.clone(),
             liquidity_token: Addr::unchecked(""),
             asset_infos: msg.asset_infos.clone(),
-            pair_type: PairType::Xyk {},
+            pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         },
         factory_addr: deps.api.addr_validate(msg.factory_addr.as_str())?,
         block_time_last: 0,

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -1325,7 +1325,7 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
     // If migrating from default xyk pair, we must make some state changes
     if contract_version.contract == "astroport-pair" {
         match contract_version.version.as_str() {
-            "1.3.0" | "1.3.1" | "1.4.0" => {}
+            "1.3.0" | "1.3.1" | "1.4.0" | "1.5.0" => {}
             _ => return Err(StdError::generic_err(
                 "Incompatible version of astroport-pair. Only 1.3.0, 1.3.1, and 1.4.0 supported.",
             )

--- a/contracts/pair_xyk_sale_tax/src/error.rs
+++ b/contracts/pair_xyk_sale_tax/src/error.rs
@@ -1,0 +1,61 @@
+use astroport::asset::MINIMUM_LIQUIDITY_AMOUNT;
+use cosmwasm_std::{OverflowError, StdError};
+use thiserror::Error;
+
+/// This enum describes pair contract errors
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("CW20 tokens can be swapped via Cw20::Send message only")]
+    Cw20DirectSwap {},
+
+    #[error("Operation non supported")]
+    NonSupported {},
+
+    #[error("Event of zero transfer")]
+    InvalidZeroAmount {},
+
+    #[error("Operation exceeds max spread limit")]
+    MaxSpreadAssertion {},
+
+    #[error("Provided spread amount exceeds allowed limit")]
+    AllowedSpreadAssertion {},
+
+    #[error("Operation exceeds max splippage tolerance")]
+    MaxSlippageAssertion {},
+
+    #[error("Doubling assets in asset infos")]
+    DoublingAssets {},
+
+    #[error("Asset mismatch between the requested and the stored asset in contract")]
+    AssetMismatch {},
+
+    #[error("Pair type mismatch. Check factory pair configs")]
+    PairTypeMismatch {},
+
+    #[error("Generator address is not set in factory. Cannot auto-stake")]
+    AutoStakeError {},
+
+    #[error("Initial liquidity must be more than {}", MINIMUM_LIQUIDITY_AMOUNT)]
+    MinimumLiquidityAmountError {},
+
+    #[error("Failed to migrate the contract")]
+    MigrationError {},
+
+    #[error("Asset balances tracking is already enabled")]
+    AssetBalancesTrackingIsAlreadyEnabled {},
+
+    #[error("Failed to parse or process reply message")]
+    FailedToParseReply {},
+}
+
+impl From<OverflowError> for ContractError {
+    fn from(o: OverflowError) -> Self {
+        StdError::from(o).into()
+    }
+}

--- a/contracts/pair_xyk_sale_tax/src/lib.rs
+++ b/contracts/pair_xyk_sale_tax/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod contract;
+pub mod state;
+pub mod error;
+
+
+#[cfg(test)]
+mod testing;
+
+#[cfg(test)]
+mod mock_querier;

--- a/contracts/pair_xyk_sale_tax/src/lib.rs
+++ b/contracts/pair_xyk_sale_tax/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod contract;
-pub mod state;
 pub mod error;
-
+pub mod state;
 
 #[cfg(test)]
 mod testing;

--- a/contracts/pair_xyk_sale_tax/src/mock_querier.rs
+++ b/contracts/pair_xyk_sale_tax/src/mock_querier.rs
@@ -1,0 +1,175 @@
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::{
+    from_binary, from_slice, to_binary, Addr, Coin, Empty, OwnedDeps, Querier, QuerierResult,
+    QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
+};
+use std::collections::HashMap;
+
+use astroport::factory::FeeInfoResponse;
+use astroport::factory::QueryMsg::FeeInfo;
+use cw20::{BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
+
+/// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies.
+/// This uses the Astroport CustomQuerier.
+pub fn mock_dependencies(
+    contract_balance: &[Coin],
+) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+    let custom_querier: WasmMockQuerier =
+        WasmMockQuerier::new(MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)]));
+
+    OwnedDeps {
+        storage: MockStorage::default(),
+        api: MockApi::default(),
+        querier: custom_querier,
+        custom_query_type: Default::default(),
+    }
+}
+
+pub struct WasmMockQuerier {
+    base: MockQuerier<Empty>,
+    token_querier: TokenQuerier,
+}
+
+#[derive(Clone, Default)]
+pub struct TokenQuerier {
+    // This lets us iterate over all pairs that match the first string
+    balances: HashMap<String, HashMap<String, Uint128>>,
+}
+
+impl TokenQuerier {
+    pub fn new(balances: &[(&String, &[(&String, &Uint128)])]) -> Self {
+        TokenQuerier {
+            balances: balances_to_map(balances),
+        }
+    }
+}
+
+pub(crate) fn balances_to_map(
+    balances: &[(&String, &[(&String, &Uint128)])],
+) -> HashMap<String, HashMap<String, Uint128>> {
+    let mut balances_map: HashMap<String, HashMap<String, Uint128>> = HashMap::new();
+    for (contract_addr, balances) in balances.iter() {
+        let mut contract_balances_map: HashMap<String, Uint128> = HashMap::new();
+        for (addr, balance) in balances.iter() {
+            contract_balances_map.insert(addr.to_string(), **balance);
+        }
+
+        balances_map.insert(contract_addr.to_string(), contract_balances_map);
+    }
+    balances_map
+}
+
+impl Querier for WasmMockQuerier {
+    fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
+        // MockQuerier doesn't support Custom, so we ignore it completely
+        let request: QueryRequest<Empty> = match from_slice(bin_request) {
+            Ok(v) => v,
+            Err(e) => {
+                return SystemResult::Err(SystemError::InvalidRequest {
+                    error: format!("Parsing query request: {}", e),
+                    request: bin_request.into(),
+                })
+            }
+        };
+        self.handle_query(&request)
+    }
+}
+
+impl WasmMockQuerier {
+    pub fn handle_query(&self, request: &QueryRequest<Empty>) -> QuerierResult {
+        match &request {
+            QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
+                if contract_addr == "factory" {
+                    match from_binary(&msg).unwrap() {
+                        FeeInfo { .. } => SystemResult::Ok(
+                            to_binary(&FeeInfoResponse {
+                                fee_address: Some(Addr::unchecked("fee_address")),
+                                total_fee_bps: 30,
+                                maker_fee_bps: 1660,
+                            })
+                            .into(),
+                        ),
+                        _ => panic!("DO NOT ENTER HERE"),
+                    }
+                } else {
+                    match from_binary(&msg).unwrap() {
+                        Cw20QueryMsg::TokenInfo {} => {
+                            let balances: &HashMap<String, Uint128> =
+                                match self.token_querier.balances.get(contract_addr) {
+                                    Some(balances) => balances,
+                                    None => {
+                                        return SystemResult::Err(SystemError::Unknown {});
+                                    }
+                                };
+
+                            let mut total_supply = Uint128::zero();
+
+                            for balance in balances {
+                                total_supply += *balance.1;
+                            }
+
+                            SystemResult::Ok(
+                                to_binary(&TokenInfoResponse {
+                                    name: "mAPPL".to_string(),
+                                    symbol: "mAPPL".to_string(),
+                                    decimals: 6,
+                                    total_supply: total_supply,
+                                })
+                                .into(),
+                            )
+                        }
+                        Cw20QueryMsg::Balance { address } => {
+                            let balances: &HashMap<String, Uint128> =
+                                match self.token_querier.balances.get(contract_addr) {
+                                    Some(balances) => balances,
+                                    None => {
+                                        return SystemResult::Err(SystemError::Unknown {});
+                                    }
+                                };
+
+                            let balance = match balances.get(&address) {
+                                Some(v) => v,
+                                None => {
+                                    return SystemResult::Err(SystemError::Unknown {});
+                                }
+                            };
+
+                            SystemResult::Ok(
+                                to_binary(&BalanceResponse { balance: *balance }).into(),
+                            )
+                        }
+                        _ => panic!("DO NOT ENTER HERE"),
+                    }
+                }
+            }
+            QueryRequest::Wasm(WasmQuery::Raw { contract_addr, .. }) => {
+                if contract_addr == "factory" {
+                    SystemResult::Ok(to_binary(&Vec::<Addr>::new()).into())
+                } else {
+                    panic!("DO NOT ENTER HERE");
+                }
+            }
+            _ => self.base.handle_query(request),
+        }
+    }
+}
+
+impl WasmMockQuerier {
+    pub fn new(base: MockQuerier<Empty>) -> Self {
+        WasmMockQuerier {
+            base,
+            token_querier: TokenQuerier::default(),
+        }
+    }
+
+    // Configure the mint whitelist mock querier
+    pub fn with_token_balances(&mut self, balances: &[(&String, &[(&String, &Uint128)])]) {
+        self.token_querier = TokenQuerier::new(balances);
+    }
+
+    pub fn with_balance(&mut self, balances: &[(&String, &[Coin])]) {
+        for (addr, balance) in balances {
+            self.base.update_balance(addr.to_string(), balance.to_vec());
+        }
+    }
+}

--- a/contracts/pair_xyk_sale_tax/src/state.rs
+++ b/contracts/pair_xyk_sale_tax/src/state.rs
@@ -1,0 +1,32 @@
+use astroport::asset::{AssetInfo, PairInfo};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, SnapshotMap};
+
+/// This structure stores the main config parameters for a constant product pair contract.
+#[cw_serde]
+pub struct Config {
+    /// General pair information (e.g pair type)
+    pub pair_info: PairInfo,
+    /// The factory contract address
+    pub factory_addr: Addr,
+    /// The last timestamp when the pair contract update the asset cumulative prices
+    pub block_time_last: u64,
+    /// The last cumulative price for asset 0
+    pub price0_cumulative_last: Uint128,
+    /// The last cumulative price for asset 1
+    pub price1_cumulative_last: Uint128,
+    /// Whether asset balances are tracked over blocks or not.
+    pub track_asset_balances: bool,
+}
+
+/// Stores the config struct at the given key
+pub const CONFIG: Item<Config> = Item::new("config");
+
+/// Stores asset balances to query them later at any block height
+pub const BALANCES: SnapshotMap<&AssetInfo, Uint128> = SnapshotMap::new(
+    "balances",
+    "balances_check",
+    "balances_change",
+    cw_storage_plus::Strategy::EveryBlock,
+);

--- a/contracts/pair_xyk_sale_tax/src/state.rs
+++ b/contracts/pair_xyk_sale_tax/src/state.rs
@@ -23,6 +23,8 @@ pub struct Config {
     pub track_asset_balances: bool,
     /// The configs of the sale taxes
     pub tax_configs: TaxConfigs<Addr>,
+    /// The address that is allowed to updated the tax configs
+    pub tax_config_admin: Addr,
 }
 
 /// Stores the config struct at the given key

--- a/contracts/pair_xyk_sale_tax/src/state.rs
+++ b/contracts/pair_xyk_sale_tax/src/state.rs
@@ -3,6 +3,8 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, SnapshotMap};
 
+use astroport::pair_xyk_sale_tax::TaxConfigChecked;
+
 /// This structure stores the main config parameters for a constant product pair contract.
 #[cw_serde]
 pub struct Config {
@@ -18,6 +20,8 @@ pub struct Config {
     pub price1_cumulative_last: Uint128,
     /// Whether asset balances are tracked over blocks or not.
     pub track_asset_balances: bool,
+    /// The config of the sales tax
+    pub tax_config: TaxConfigChecked,
 }
 
 /// Stores the config struct at the given key

--- a/contracts/pair_xyk_sale_tax/src/state.rs
+++ b/contracts/pair_xyk_sale_tax/src/state.rs
@@ -1,9 +1,10 @@
-use astroport::asset::{AssetInfo, PairInfo};
+use astroport::{
+    asset::{AssetInfo, PairInfo},
+    pair_xyk_sale_tax::TaxConfigs,
+};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, SnapshotMap};
-
-use astroport::pair_xyk_sale_tax::TaxConfigChecked;
 
 /// This structure stores the main config parameters for a constant product pair contract.
 #[cw_serde]
@@ -20,8 +21,8 @@ pub struct Config {
     pub price1_cumulative_last: Uint128,
     /// Whether asset balances are tracked over blocks or not.
     pub track_asset_balances: bool,
-    /// The config of the sales tax
-    pub tax_config: TaxConfigChecked,
+    /// The configs of the sale taxes
+    pub tax_configs: TaxConfigs<Addr>,
 }
 
 /// Stores the config struct at the given key

--- a/contracts/pair_xyk_sale_tax/src/testing.rs
+++ b/contracts/pair_xyk_sale_tax/src/testing.rs
@@ -15,12 +15,12 @@ use astroport::pair::{
 };
 use astroport::token::InstantiateMsg as TokenInstantiateMsg;
 
-use crate::contract::compute_offer_amount;
 use crate::contract::reply;
 use crate::contract::{
     accumulate_prices, assert_max_spread, compute_swap, execute, instantiate, query_pool,
     query_reverse_simulation, query_share, query_simulation,
 };
+use crate::contract::{compute_offer_amount, SwapResult};
 use crate::error::ContractError;
 use crate::mock_querier::mock_dependencies;
 use crate::state::{Config, CONFIG};
@@ -1481,11 +1481,14 @@ fn mock_env_with_block_time(time: u64) -> Env {
 fn compute_swap_rounding() {
     let offer_pool = Uint128::from(5_000_000_000_000_u128);
     let ask_pool = Uint128::from(1_000_000_000_u128);
-    let return_amount = Uint128::from(0_u128);
-    let spread_amount = Uint128::from(0_u128);
-    let commission_amount = Uint128::from(0_u128);
     let offer_amount = Uint128::from(1_u128);
-    let sale_tax = Uint128::zero();
+    let swap_result = SwapResult {
+        return_amount: Uint128::zero(),
+        spread_amount: Uint128::zero(),
+        commission_amount: Uint128::zero(),
+        offer_amount,
+        sale_tax: Uint128::zero(),
+    };
 
     assert_eq!(
         compute_swap(
@@ -1495,13 +1498,7 @@ fn compute_swap_rounding() {
             Decimal::zero(),
             None
         ),
-        Ok((
-            return_amount,
-            spread_amount,
-            commission_amount,
-            offer_amount,
-            sale_tax
-        ))
+        Ok(swap_result)
     );
 }
 

--- a/contracts/pair_xyk_sale_tax/src/testing.rs
+++ b/contracts/pair_xyk_sale_tax/src/testing.rs
@@ -1444,6 +1444,7 @@ fn test_accumulate_prices() {
                 price1_cumulative_last: Uint128::new(case.last1),
                 track_asset_balances: false,
                 tax_configs: TaxConfigsChecked::default(),
+                tax_config_admin: Addr::unchecked("tax_config_admin"),
             },
             Uint128::new(case.x_amount),
             Uint128::new(case.y_amount),

--- a/contracts/pair_xyk_sale_tax/src/testing.rs
+++ b/contracts/pair_xyk_sale_tax/src/testing.rs
@@ -1,0 +1,1560 @@
+use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::{
+    attr, to_binary, Addr, BankMsg, BlockInfo, Coin, CosmosMsg, Decimal, DepsMut, Env, Reply,
+    ReplyOn, Response, StdError, SubMsg, SubMsgResponse, SubMsgResult, Timestamp, Uint128, WasmMsg,
+};
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg, MinterResponse};
+use proptest::prelude::*;
+
+use astroport::asset::{Asset, AssetInfo, PairInfo};
+use astroport::factory::PairType;
+use astroport::pair::{
+    Cw20HookMsg, ExecuteMsg, InstantiateMsg, PoolResponse, ReverseSimulationResponse,
+    SimulationResponse, TWAP_PRECISION,
+};
+use astroport::token::InstantiateMsg as TokenInstantiateMsg;
+
+use crate::contract::compute_offer_amount;
+use crate::contract::reply;
+use crate::contract::{
+    accumulate_prices, assert_max_spread, compute_swap, execute, instantiate, query_pool,
+    query_reverse_simulation, query_share, query_simulation,
+};
+use crate::error::ContractError;
+use crate::mock_querier::mock_dependencies;
+use crate::state::{Config, CONFIG};
+
+use prost::Message;
+
+#[derive(Clone, PartialEq, Message)]
+struct MsgInstantiateContractResponse {
+    #[prost(string, tag = "1")]
+    pub contract_address: String,
+    #[prost(bytes, tag = "2")]
+    pub data: Vec<u8>,
+}
+
+fn store_liquidity_token(deps: DepsMut, msg_id: u64, contract_addr: String) {
+    let instantiate_reply = MsgInstantiateContractResponse {
+        contract_address: contract_addr,
+        data: vec![],
+    };
+
+    let mut encoded_instantiate_reply = Vec::<u8>::with_capacity(instantiate_reply.encoded_len());
+    instantiate_reply
+        .encode(&mut encoded_instantiate_reply)
+        .unwrap();
+
+    let reply_msg = Reply {
+        id: msg_id,
+        result: SubMsgResult::Ok(SubMsgResponse {
+            events: vec![],
+            data: Some(encoded_instantiate_reply.into()),
+        }),
+    };
+
+    let _res = reply(deps, mock_env(), reply_msg.clone()).unwrap();
+}
+
+#[test]
+fn proper_initialization() {
+    let mut deps = mock_dependencies(&[]);
+
+    deps.querier.with_token_balances(&[(
+        &String::from("asset0000"),
+        &[(&String::from(MOCK_CONTRACT_ADDR), &Uint128::new(123u128))],
+    )]);
+
+    let msg = InstantiateMsg {
+        factory_addr: String::from("factory"),
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+        ],
+        token_code_id: 10u64,
+        init_params: None,
+    };
+
+    let sender = "addr0000";
+    // We can just call .unwrap() to assert this was a success
+    let env = mock_env();
+    let info = mock_info(sender, &[]);
+    let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+    assert_eq!(
+        res.messages,
+        vec![SubMsg {
+            msg: WasmMsg::Instantiate {
+                code_id: 10u64,
+                msg: to_binary(&TokenInstantiateMsg {
+                    name: "UUSD-MAPP-LP".to_string(),
+                    symbol: "uLP".to_string(),
+                    decimals: 6,
+                    initial_balances: vec![],
+                    mint: Some(MinterResponse {
+                        minter: String::from(MOCK_CONTRACT_ADDR),
+                        cap: None,
+                    }),
+                    marketing: None
+                })
+                .unwrap(),
+                funds: vec![],
+                admin: None,
+                label: String::from("Astroport LP token"),
+            }
+            .into(),
+            id: 1,
+            gas_limit: None,
+            reply_on: ReplyOn::Success
+        },]
+    );
+
+    // Store liquidity token
+    store_liquidity_token(deps.as_mut(), 1, "liquidity0000".to_string());
+
+    // It worked, let's query the state
+    let pair_info = CONFIG.load(deps.as_ref().storage).unwrap().pair_info;
+    assert_eq!(Addr::unchecked("liquidity0000"), pair_info.liquidity_token);
+    assert_eq!(
+        pair_info.asset_infos,
+        [
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000")
+            }
+        ]
+    );
+}
+
+#[test]
+fn provide_liquidity() {
+    let mut deps = mock_dependencies(&[Coin {
+        denom: "uusd".to_string(),
+        amount: Uint128::new(200_000000000000000000u128),
+    }]);
+
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("asset0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &Uint128::new(0))],
+        ),
+        (
+            &String::from("liquidity0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &Uint128::new(0))],
+        ),
+    ]);
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+        ],
+        token_code_id: 10u64,
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let env = mock_env();
+    let info = mock_info("addr0000", &[]);
+    // We can just call .unwrap() to assert this was a success
+    let _res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+
+    // Store liquidity token
+    store_liquidity_token(deps.as_mut(), 1, "liquidity0000".to_string());
+
+    // Successfully provide liquidity for the existing pool
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: None,
+        auto_stake: None,
+        receiver: None,
+    };
+
+    let env = mock_env();
+    let info = mock_info(
+        "addr0000",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(100_000000000000000000u128),
+        }],
+    );
+    let res = execute(deps.as_mut(), env.clone().clone(), info, msg).unwrap();
+    let transfer_from_msg = res.messages.get(0).expect("no message");
+    let mint_min_liquidity_msg = res.messages.get(1).expect("no message");
+    let mint_receiver_msg = res.messages.get(2).expect("no message");
+    assert_eq!(
+        transfer_from_msg,
+        &SubMsg {
+            msg: WasmMsg::Execute {
+                contract_addr: String::from("asset0000"),
+                msg: to_binary(&Cw20ExecuteMsg::TransferFrom {
+                    owner: String::from("addr0000"),
+                    recipient: String::from(MOCK_CONTRACT_ADDR),
+                    amount: Uint128::from(100_000000000000000000u128),
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never
+        }
+    );
+    assert_eq!(
+        mint_min_liquidity_msg,
+        &SubMsg {
+            msg: WasmMsg::Execute {
+                contract_addr: String::from("liquidity0000"),
+                msg: to_binary(&Cw20ExecuteMsg::Mint {
+                    recipient: String::from(MOCK_CONTRACT_ADDR),
+                    amount: Uint128::from(1000_u128),
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        mint_receiver_msg,
+        &SubMsg {
+            msg: WasmMsg::Execute {
+                contract_addr: String::from("liquidity0000"),
+                msg: to_binary(&Cw20ExecuteMsg::Mint {
+                    recipient: String::from("addr0000"),
+                    amount: Uint128::from(99_999999999999999000u128),
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+
+    // Provide more liquidity 1:2, which is not propotional to 1:1,
+    // It must accept 1:1 and treat the leftover amount as a donation
+    deps.querier.with_balance(&[(
+        &String::from(MOCK_CONTRACT_ADDR),
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::new(200_000000000000000000 + 200_000000000000000000 /* user deposit must be pre-applied */),
+        }],
+    )]);
+
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("liquidity0000"),
+            &[(
+                &String::from(MOCK_CONTRACT_ADDR),
+                &Uint128::new(100_000000000000000000),
+            )],
+        ),
+        (
+            &String::from("asset0000"),
+            &[(
+                &String::from(MOCK_CONTRACT_ADDR),
+                &Uint128::new(200_000000000000000000),
+            )],
+        ),
+    ]);
+
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(200_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: Some(Decimal::percent(50)),
+        auto_stake: None,
+        receiver: None,
+    };
+
+    let env = mock_env_with_block_time(env.block.time.seconds() + 1000);
+    let info = mock_info(
+        "addr0000",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(200_000000000000000000u128),
+        }],
+    );
+
+    // Only accept 100, then 50 share will be generated with 100 * (100 / 200)
+    let res: Response = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+    let transfer_from_msg = res.messages.get(0).expect("no message");
+    let mint_msg = res.messages.get(1).expect("no message");
+    assert_eq!(
+        transfer_from_msg,
+        &SubMsg {
+            msg: WasmMsg::Execute {
+                contract_addr: String::from("asset0000"),
+                msg: to_binary(&Cw20ExecuteMsg::TransferFrom {
+                    owner: String::from("addr0000"),
+                    recipient: String::from(MOCK_CONTRACT_ADDR),
+                    amount: Uint128::from(100_000000000000000000u128),
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        mint_msg,
+        &SubMsg {
+            msg: WasmMsg::Execute {
+                contract_addr: String::from("liquidity0000"),
+                msg: to_binary(&Cw20ExecuteMsg::Mint {
+                    recipient: String::from("addr0000"),
+                    amount: Uint128::from(50_000000000000000000u128),
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+
+    // Check wrong argument
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(50_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: None,
+        auto_stake: None,
+        receiver: None,
+    };
+
+    let env = mock_env();
+    let info = mock_info(
+        "addr0000",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(100_000000000000000000u128),
+        }],
+    );
+    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
+    assert_eq!(
+        res,
+        ContractError::Std(StdError::generic_err(
+            "Native token balance mismatch between the argument and the transferred",
+        ))
+    );
+
+    // Initialize token amount to the 1:1 ratio
+    deps.querier.with_balance(&[(
+        &String::from(MOCK_CONTRACT_ADDR),
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::new(100_000000000000000000 + 100_000000000000000000 /* user deposit must be pre-applied */),
+        }],
+    )]);
+
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("liquidity0000"),
+            &[(
+                &String::from(MOCK_CONTRACT_ADDR),
+                &Uint128::new(100_000000000000000000),
+            )],
+        ),
+        (
+            &String::from("asset0000"),
+            &[(
+                &String::from(MOCK_CONTRACT_ADDR),
+                &Uint128::new(100_000000000000000000),
+            )],
+        ),
+    ]);
+
+    // Failed because the price is under slippage_tolerance
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::from(98_000000000000000000u128),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: Some(Decimal::percent(1)),
+        auto_stake: None,
+        receiver: None,
+    };
+
+    let env = mock_env_with_block_time(env.block.time.seconds() + 1000);
+    let info = mock_info(
+        "addr0001",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(100_000000000000000000u128),
+        }],
+    );
+    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
+    assert_eq!(res, ContractError::MaxSlippageAssertion {});
+
+    // Initialize token balance to 1:1
+    deps.querier.with_balance(&[(
+        &String::from(MOCK_CONTRACT_ADDR),
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::new(100_000000000000000000 + 98_000000000000000000 /* user deposit must be pre-applied */),
+        }],
+    )]);
+
+    // Failed because the price is under slippage_tolerance
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(98_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: Some(Decimal::percent(1)),
+        auto_stake: None,
+        receiver: None,
+    };
+
+    let env = mock_env_with_block_time(env.block.time.seconds() + 1000);
+    let info = mock_info(
+        "addr0001",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(98_000000000000000000u128),
+        }],
+    );
+    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
+    assert_eq!(res, ContractError::MaxSlippageAssertion {});
+
+    // Initialize token amount with a 1:1 ratio
+    deps.querier.with_balance(&[(
+        &String::from(MOCK_CONTRACT_ADDR),
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::new(100_000000000000000000 + 100_000000000000000000 /* user deposit must be pre-applied */),
+        }],
+    )]);
+
+    // Successfully provides liquidity
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::from(99_000000000000000000u128),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: Some(Decimal::percent(1)),
+        auto_stake: None,
+        receiver: None,
+    };
+
+    let env = mock_env_with_block_time(env.block.time.seconds() + 1000);
+    let info = mock_info(
+        "addr0001",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(100_000000000000000000u128),
+        }],
+    );
+    let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+    // Initialize token balance to 1:1
+    deps.querier.with_balance(&[(
+        &String::from(MOCK_CONTRACT_ADDR),
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::new(100_000000000000000000 + 99_000000000000000000 /* user deposit must be pre-applied */),
+        }],
+    )]);
+
+    // Successfully provides liquidity
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(99_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: Some(Decimal::percent(1)),
+        auto_stake: None,
+        receiver: None,
+    };
+
+    let env = mock_env_with_block_time(env.block.time.seconds() + 1000);
+    let info = mock_info(
+        "addr0001",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(99_000000000000000000u128),
+        }],
+    );
+    execute(deps.as_mut(), env, info, msg).unwrap();
+
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::zero(),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(99_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: Some(Decimal::percent(1)),
+        auto_stake: None,
+        receiver: None,
+    };
+    let info = mock_info(
+        "addr0001",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(99_000000000000000000u128),
+        }],
+    );
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+    assert_eq!(err, ContractError::InvalidZeroAmount {});
+
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(100_000000000000000000u128),
+            },
+        ],
+        slippage_tolerance: Some(Decimal::percent(51)),
+        auto_stake: None,
+        receiver: None,
+    };
+    let info = mock_info(
+        "addr0001",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(100_000000000000000000u128),
+        }],
+    );
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+    assert_eq!(err, ContractError::AllowedSpreadAssertion {});
+}
+
+#[test]
+fn withdraw_liquidity() {
+    let mut deps = mock_dependencies(&[Coin {
+        denom: "uusd".to_string(),
+        amount: Uint128::new(100u128),
+    }]);
+
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("liquidity0000"),
+            &[(&String::from("addr0000"), &Uint128::new(100u128))],
+        ),
+        (
+            &String::from("asset0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &Uint128::new(100u128))],
+        ),
+    ]);
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+        ],
+        token_code_id: 10u64,
+
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let env = mock_env();
+    let info = mock_info("addr0000", &[]);
+    // We can just call .unwrap() to assert this was a success
+    let _res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+
+    // Store liquidity token
+    store_liquidity_token(deps.as_mut(), 1, "liquidity0000".to_string());
+
+    // Withdraw liquidity
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: String::from("addr0000"),
+        msg: to_binary(&Cw20HookMsg::WithdrawLiquidity { assets: vec![] }).unwrap(),
+        amount: Uint128::new(100u128),
+    });
+
+    let env = mock_env();
+    let info = mock_info("liquidity0000", &[]);
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
+    let log_withdrawn_share = res.attributes.get(2).expect("no log");
+    let log_refund_assets = res.attributes.get(3).expect("no log");
+    let msg_refund_0 = res.messages.get(0).expect("no message");
+    let msg_refund_1 = res.messages.get(1).expect("no message");
+    let msg_burn_liquidity = res.messages.get(2).expect("no message");
+    assert_eq!(
+        msg_refund_0,
+        &SubMsg {
+            msg: CosmosMsg::Bank(BankMsg::Send {
+                to_address: String::from("addr0000"),
+                amount: vec![Coin {
+                    denom: "uusd".to_string(),
+                    amount: Uint128::from(100u128),
+                }],
+            }),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        msg_refund_1,
+        &SubMsg {
+            msg: WasmMsg::Execute {
+                contract_addr: String::from("asset0000"),
+                msg: to_binary(&Cw20ExecuteMsg::Transfer {
+                    recipient: String::from("addr0000"),
+                    amount: Uint128::from(100u128),
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        msg_burn_liquidity,
+        &SubMsg {
+            msg: WasmMsg::Execute {
+                contract_addr: String::from("liquidity0000"),
+                msg: to_binary(&Cw20ExecuteMsg::Burn {
+                    amount: Uint128::from(100u128),
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+
+    assert_eq!(
+        log_withdrawn_share,
+        &attr("withdrawn_share", 100u128.to_string())
+    );
+    assert_eq!(
+        log_refund_assets,
+        &attr("refund_assets", "100uusd, 100asset0000")
+    );
+}
+
+#[test]
+fn try_native_to_token() {
+    let total_share = Uint128::new(30000000000u128);
+    let asset_pool_amount = Uint128::new(20000000000u128);
+    let collateral_pool_amount = Uint128::new(30000000000u128);
+    let offer_amount = Uint128::new(1500000000u128);
+
+    let mut deps = mock_dependencies(&[Coin {
+        denom: "uusd".to_string(),
+        amount: collateral_pool_amount + offer_amount, /* user deposit must be pre-applied */
+    }]);
+
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("liquidity0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &total_share)],
+        ),
+        (
+            &String::from("asset0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &asset_pool_amount)],
+        ),
+    ]);
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+        ],
+        token_code_id: 10u64,
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let env = mock_env();
+    let info = mock_info("addr0000", &[]);
+    // we can just call .unwrap() to assert this was a success
+    let _res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+
+    // Store liquidity token
+    store_liquidity_token(deps.as_mut(), 1, "liquidity0000".to_string());
+
+    // Normal swap
+    let msg = ExecuteMsg::Swap {
+        offer_asset: Asset {
+            info: AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            amount: offer_amount,
+        },
+        ask_asset_info: None,
+        belief_price: None,
+        max_spread: Some(Decimal::percent(50)),
+        to: None,
+    };
+    let env = mock_env_with_block_time(1000);
+    let info = mock_info(
+        "addr0000",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: offer_amount,
+        }],
+    );
+
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
+    let msg_transfer = res.messages.get(0).expect("no message");
+
+    // Current price is 1.5, so expected return without spread is 1000
+    // 952380952 = 20000000000 - (30000000000 * 20000000000) / (30000000000 + 1500000000)
+    let expected_ret_amount = Uint128::new(952_380_952u128);
+
+    // 47619047 = 1500000000 * (20000000000 / 30000000000) - 952380952
+    let expected_spread_amount = Uint128::new(47619047u128);
+
+    let expected_commission_amount = expected_ret_amount.multiply_ratio(3u128, 1000u128); // 0.3%
+    let expected_maker_fee_amount = expected_commission_amount.multiply_ratio(166u128, 1000u128); // 0.166
+
+    let expected_return_amount = expected_ret_amount
+        .checked_sub(expected_commission_amount)
+        .unwrap();
+
+    // Check simulation result
+    deps.querier.with_balance(&[(
+        &String::from(MOCK_CONTRACT_ADDR),
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: collateral_pool_amount, /* user deposit must be pre-applied */
+        }],
+    )]);
+
+    let err = query_simulation(
+        deps.as_ref(),
+        Asset {
+            info: AssetInfo::NativeToken {
+                denom: "cny".to_string(),
+            },
+            amount: offer_amount,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Generic error: Given offer asset does not belong in the pair"
+    );
+
+    let simulation_res: SimulationResponse = query_simulation(
+        deps.as_ref(),
+        Asset {
+            info: AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            amount: offer_amount,
+        },
+    )
+    .unwrap();
+    assert_eq!(expected_return_amount, simulation_res.return_amount);
+    assert_eq!(expected_commission_amount, simulation_res.commission_amount);
+    assert_eq!(expected_spread_amount, simulation_res.spread_amount);
+
+    // Check reverse simulation result
+    let err = query_reverse_simulation(
+        deps.as_ref(),
+        Asset {
+            info: AssetInfo::NativeToken {
+                denom: "cny".to_string(),
+            },
+            amount: expected_return_amount,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Generic error: Given ask asset doesn't belong to pairs"
+    );
+
+    let reverse_simulation_res: ReverseSimulationResponse = query_reverse_simulation(
+        deps.as_ref(),
+        Asset {
+            info: AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+            amount: expected_return_amount,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        (offer_amount.u128() as i128 - reverse_simulation_res.offer_amount.u128() as i128).abs()
+            < 5i128,
+        true
+    );
+    assert_eq!(
+        (expected_commission_amount.u128() as i128
+            - reverse_simulation_res.commission_amount.u128() as i128)
+            .abs()
+            < 5i128,
+        true
+    );
+    assert_eq!(
+        (expected_spread_amount.u128() as i128
+            - reverse_simulation_res.spread_amount.u128() as i128)
+            .abs()
+            < 5i128,
+        true
+    );
+
+    assert_eq!(
+        res.attributes,
+        vec![
+            attr("action", "swap"),
+            attr("sender", "addr0000"),
+            attr("receiver", "addr0000"),
+            attr("offer_asset", "uusd"),
+            attr("ask_asset", "asset0000"),
+            attr("offer_amount", offer_amount.to_string()),
+            attr("return_amount", expected_return_amount.to_string()),
+            attr("spread_amount", expected_spread_amount.to_string()),
+            attr("commission_amount", expected_commission_amount.to_string()),
+            attr("maker_fee_amount", expected_maker_fee_amount.to_string()),
+        ]
+    );
+
+    assert_eq!(
+        &SubMsg {
+            msg: WasmMsg::Execute {
+                contract_addr: String::from("asset0000"),
+                msg: to_binary(&Cw20ExecuteMsg::Transfer {
+                    recipient: String::from("addr0000"),
+                    amount: Uint128::from(expected_return_amount),
+                })
+                .unwrap(),
+                funds: vec![],
+            }
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        },
+        msg_transfer,
+    );
+}
+
+#[test]
+fn try_token_to_native() {
+    let total_share = Uint128::new(20000000000u128);
+    let asset_pool_amount = Uint128::new(30000000000u128);
+    let collateral_pool_amount = Uint128::new(20000000000u128);
+    let offer_amount = Uint128::new(1500000000u128);
+
+    let mut deps = mock_dependencies(&[Coin {
+        denom: "uusd".to_string(),
+        amount: collateral_pool_amount,
+    }]);
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("liquidity0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &total_share)],
+        ),
+        (
+            &String::from("asset0000"),
+            &[(
+                &String::from(MOCK_CONTRACT_ADDR),
+                &(asset_pool_amount + offer_amount),
+            )],
+        ),
+    ]);
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+        ],
+        token_code_id: 10u64,
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let env = mock_env();
+    let info = mock_info("addr0000", &[]);
+    // We can just call .unwrap() to assert this was a success
+    let _res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+
+    // Store liquidity token
+    store_liquidity_token(deps.as_mut(), 1, "liquidity0000".to_string());
+
+    // Unauthorized access; can not execute swap directly for token swap
+    let msg = ExecuteMsg::Swap {
+        offer_asset: Asset {
+            info: AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+            amount: offer_amount,
+        },
+        ask_asset_info: None,
+        belief_price: None,
+        max_spread: None,
+        to: None,
+    };
+    let env = mock_env_with_block_time(1000);
+    let info = mock_info("addr0000", &[]);
+    let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    assert_eq!(res, ContractError::Cw20DirectSwap {});
+
+    // Normal sell
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: String::from("addr0000"),
+        amount: offer_amount,
+        msg: to_binary(&Cw20HookMsg::Swap {
+            ask_asset_info: None,
+            belief_price: None,
+            max_spread: Some(Decimal::percent(50)),
+            to: None,
+        })
+        .unwrap(),
+    });
+    let env = mock_env_with_block_time(1000);
+    let info = mock_info("asset0000", &[]);
+
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
+    let msg_transfer = res.messages.get(0).expect("no message");
+
+    // Current price is 1.5, so expected return without spread is 1000
+    // 952380952,3809524 = 20000000000 - (30000000000 * 20000000000) / (30000000000 + 1500000000)
+    let expected_ret_amount = Uint128::new(952_380_952u128);
+
+    // 47619047 = 1500000000 * (20000000000 / 30000000000) - 952380952,3809524
+    let expected_spread_amount = Uint128::new(47619047u128);
+
+    let expected_commission_amount = expected_ret_amount.multiply_ratio(3u128, 1000u128); // 0.3%
+    let expected_maker_fee_amount = expected_commission_amount.multiply_ratio(166u128, 1000u128);
+    let expected_return_amount = expected_ret_amount
+        .checked_sub(expected_commission_amount)
+        .unwrap();
+
+    // Check simulation res
+    // Return asset token balance as normal
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("liquidity0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &total_share)],
+        ),
+        (
+            &String::from("asset0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &(asset_pool_amount))],
+        ),
+    ]);
+
+    let simulation_res: SimulationResponse = query_simulation(
+        deps.as_ref(),
+        Asset {
+            amount: offer_amount,
+            info: AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+        },
+    )
+    .unwrap();
+    assert_eq!(expected_return_amount, simulation_res.return_amount);
+    assert_eq!(expected_commission_amount, simulation_res.commission_amount);
+    assert_eq!(expected_spread_amount, simulation_res.spread_amount);
+
+    // Check reverse simulation result
+    let reverse_simulation_res: ReverseSimulationResponse = query_reverse_simulation(
+        deps.as_ref(),
+        Asset {
+            amount: expected_return_amount,
+            info: AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        (offer_amount.u128() as i128 - reverse_simulation_res.offer_amount.u128() as i128).abs()
+            < 5i128,
+        true
+    );
+    assert_eq!(
+        (expected_commission_amount.u128() as i128
+            - reverse_simulation_res.commission_amount.u128() as i128)
+            .abs()
+            < 5i128,
+        true
+    );
+    assert_eq!(
+        (expected_spread_amount.u128() as i128
+            - reverse_simulation_res.spread_amount.u128() as i128)
+            .abs()
+            < 5i128,
+        true
+    );
+
+    assert_eq!(
+        res.attributes,
+        vec![
+            attr("action", "swap"),
+            attr("sender", "addr0000"),
+            attr("receiver", "addr0000"),
+            attr("offer_asset", "asset0000"),
+            attr("ask_asset", "uusd"),
+            attr("offer_amount", offer_amount.to_string()),
+            attr("return_amount", expected_return_amount.to_string()),
+            attr("spread_amount", expected_spread_amount.to_string()),
+            attr("commission_amount", expected_commission_amount.to_string()),
+            attr("maker_fee_amount", expected_maker_fee_amount.to_string()),
+        ]
+    );
+
+    assert_eq!(
+        &SubMsg {
+            msg: CosmosMsg::Bank(BankMsg::Send {
+                to_address: String::from("addr0000"),
+                amount: vec![Coin {
+                    denom: "uusd".to_string(),
+                    amount: expected_return_amount
+                }],
+            })
+            .into(),
+            id: 0,
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        },
+        msg_transfer,
+    );
+
+    // Failed due to trying to swap a non token (specifying an address of a non token contract)
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: String::from("addr0000"),
+        amount: offer_amount,
+        msg: to_binary(&Cw20HookMsg::Swap {
+            ask_asset_info: None,
+            belief_price: None,
+            max_spread: None,
+            to: None,
+        })
+        .unwrap(),
+    });
+    let env = mock_env_with_block_time(1000);
+    let info = mock_info("liquidtity0000", &[]);
+    let res = execute(deps.as_mut(), env, info, msg).unwrap_err();
+    assert_eq!(res, ContractError::Unauthorized {});
+}
+
+#[test]
+fn test_max_spread() {
+    assert_max_spread(
+        Some(Decimal::from_ratio(1200u128, 1u128)),
+        Some(Decimal::percent(1)),
+        Uint128::from(1200000000u128),
+        Uint128::from(989999u128),
+        Uint128::zero(),
+    )
+    .unwrap_err();
+
+    assert_max_spread(
+        Some(Decimal::from_ratio(1200u128, 1u128)),
+        Some(Decimal::percent(1)),
+        Uint128::from(1200000000u128),
+        Uint128::from(990000u128),
+        Uint128::zero(),
+    )
+    .unwrap();
+
+    assert_max_spread(
+        None,
+        Some(Decimal::percent(1)),
+        Uint128::zero(),
+        Uint128::from(989999u128),
+        Uint128::from(10001u128),
+    )
+    .unwrap_err();
+
+    assert_max_spread(
+        None,
+        Some(Decimal::percent(1)),
+        Uint128::zero(),
+        Uint128::from(990000u128),
+        Uint128::from(10000u128),
+    )
+    .unwrap();
+
+    assert_max_spread(
+        Some(Decimal::from_ratio(1200u128, 1u128)),
+        Some(Decimal::percent(51)),
+        Uint128::from(1200000000u128),
+        Uint128::from(989999u128),
+        Uint128::zero(),
+    )
+    .unwrap_err();
+}
+
+#[test]
+fn test_query_pool() {
+    let total_share_amount = Uint128::from(111u128);
+    let asset_0_amount = Uint128::from(222u128);
+    let asset_1_amount = Uint128::from(333u128);
+    let mut deps = mock_dependencies(&[Coin {
+        denom: "uusd".to_string(),
+        amount: asset_0_amount,
+    }]);
+
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("asset0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &asset_1_amount)],
+        ),
+        (
+            &String::from("liquidity0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &total_share_amount)],
+        ),
+    ]);
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+        ],
+        token_code_id: 10u64,
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let env = mock_env();
+    let info = mock_info("addr0000", &[]);
+    // We can just call .unwrap() to assert this was a success
+    let _res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+
+    // Store liquidity token
+    store_liquidity_token(deps.as_mut(), 1, "liquidity0000".to_string());
+
+    let res: PoolResponse = query_pool(deps.as_ref()).unwrap();
+
+    assert_eq!(
+        res.assets,
+        [
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: asset_0_amount
+            },
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: Addr::unchecked("asset0000"),
+                },
+                amount: asset_1_amount
+            }
+        ]
+    );
+    assert_eq!(res.total_share, total_share_amount);
+}
+
+#[test]
+fn test_query_share() {
+    let total_share_amount = Uint128::from(500u128);
+    let asset_0_amount = Uint128::from(250u128);
+    let asset_1_amount = Uint128::from(1000u128);
+    let mut deps = mock_dependencies(&[Coin {
+        denom: "uusd".to_string(),
+        amount: asset_0_amount,
+    }]);
+
+    deps.querier.with_token_balances(&[
+        (
+            &String::from("asset0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &asset_1_amount)],
+        ),
+        (
+            &String::from("liquidity0000"),
+            &[(&String::from(MOCK_CONTRACT_ADDR), &total_share_amount)],
+        ),
+    ]);
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::Token {
+                contract_addr: Addr::unchecked("asset0000"),
+            },
+        ],
+        token_code_id: 10u64,
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let env = mock_env();
+    let info = mock_info("addr0000", &[]);
+    // We can just call .unwrap() to assert this was a success
+    let _res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+
+    // Store liquidity token
+    store_liquidity_token(deps.as_mut(), 1, "liquidity0000".to_string());
+
+    let res = query_share(deps.as_ref(), Uint128::new(250)).unwrap();
+
+    assert_eq!(res[0].amount, Uint128::new(125));
+    assert_eq!(res[1].amount, Uint128::new(500));
+}
+
+#[test]
+fn test_accumulate_prices() {
+    struct Case {
+        block_time: u64,
+        block_time_last: u64,
+        last0: u128,
+        last1: u128,
+        x_amount: u128,
+        y_amount: u128,
+    }
+
+    struct Result {
+        block_time_last: u64,
+        price_x: u128,
+        price_y: u128,
+        is_some: bool,
+    }
+
+    let price_precision = 10u128.pow(TWAP_PRECISION.into());
+
+    let test_cases: Vec<(Case, Result)> = vec![
+        (
+            Case {
+                block_time: 1000,
+                block_time_last: 0,
+                last0: 0,
+                last1: 0,
+                x_amount: 250,
+                y_amount: 500,
+            },
+            Result {
+                block_time_last: 1000,
+                price_x: 2000, // 500/250*1000
+                price_y: 500,  // 250/500*1000
+                is_some: true,
+            },
+        ),
+        // Same block height, no changes
+        (
+            Case {
+                block_time: 1000,
+                block_time_last: 1000,
+                last0: 1 * price_precision,
+                last1: 2 * price_precision,
+                x_amount: 250,
+                y_amount: 500,
+            },
+            Result {
+                block_time_last: 1000,
+                price_x: 1,
+                price_y: 2,
+                is_some: false,
+            },
+        ),
+        (
+            Case {
+                block_time: 1500,
+                block_time_last: 1000,
+                last0: 500 * price_precision,
+                last1: 2000 * price_precision,
+                x_amount: 250,
+                y_amount: 500,
+            },
+            Result {
+                block_time_last: 1500,
+                price_x: 1500, // 500 + (500/250*500)
+                price_y: 2250, // 2000 + (250/500*500)
+                is_some: true,
+            },
+        ),
+    ];
+
+    for test_case in test_cases {
+        let (case, result) = test_case;
+
+        let env = mock_env_with_block_time(case.block_time);
+        let config = accumulate_prices(
+            env,
+            &Config {
+                pair_info: PairInfo {
+                    asset_infos: vec![
+                        AssetInfo::NativeToken {
+                            denom: "uusd".to_string(),
+                        },
+                        AssetInfo::Token {
+                            contract_addr: Addr::unchecked("asset0000"),
+                        },
+                    ],
+                    contract_addr: Addr::unchecked("pair"),
+                    liquidity_token: Addr::unchecked("lp_token"),
+                    pair_type: PairType::Xyk {}, // Implemented in mock querier
+                },
+                factory_addr: Addr::unchecked("factory"),
+                block_time_last: case.block_time_last,
+                price0_cumulative_last: Uint128::new(case.last0),
+                price1_cumulative_last: Uint128::new(case.last1),
+                track_asset_balances: false,
+            },
+            Uint128::new(case.x_amount),
+            Uint128::new(case.y_amount),
+        )
+        .unwrap();
+
+        assert_eq!(result.is_some, config.is_some());
+
+        if let Some(config) = config {
+            assert_eq!(config.2, result.block_time_last);
+            assert_eq!(
+                config.0 / Uint128::from(price_precision),
+                Uint128::new(result.price_x)
+            );
+            assert_eq!(
+                config.1 / Uint128::from(price_precision),
+                Uint128::new(result.price_y)
+            );
+        }
+    }
+}
+
+fn mock_env_with_block_time(time: u64) -> Env {
+    let mut env = mock_env();
+    env.block = BlockInfo {
+        height: 1,
+        time: Timestamp::from_seconds(time),
+        chain_id: "columbus".to_string(),
+    };
+    env
+}
+
+#[test]
+fn compute_swap_rounding() {
+    let offer_pool = Uint128::from(5_000_000_000_000_u128);
+    let ask_pool = Uint128::from(1_000_000_000_u128);
+    let return_amount = Uint128::from(0_u128);
+    let spread_amount = Uint128::from(0_u128);
+    let commission_amount = Uint128::from(0_u128);
+    let offer_amount = Uint128::from(1_u128);
+
+    assert_eq!(
+        compute_swap(offer_pool, ask_pool, offer_amount, Decimal::zero()),
+        Ok((return_amount, spread_amount, commission_amount))
+    );
+}
+
+proptest! {
+    #[test]
+    fn compute_swap_overflow_test(
+        offer_pool in 1_000_000..9_000_000_000_000_000_000u128,
+        ask_pool in 1_000_000..9_000_000_000_000_000_000u128,
+        offer_amount in 1..100_000_000000u128,
+    ) {
+
+        let offer_pool = Uint128::from(offer_pool);
+        let ask_pool = Uint128::from(ask_pool);
+        let offer_amount = Uint128::from(offer_amount);
+        let commission_amount = Decimal::zero();
+
+        // Make sure there are no overflows
+        compute_swap(
+            offer_pool,
+            ask_pool,
+            offer_amount,
+            commission_amount,
+        ).unwrap();
+    }
+}
+
+#[test]
+fn ensure_useful_error_messages_are_given_on_swaps() {
+    const OFFER: Uint128 = Uint128::new(1_000_000_000000);
+    const ASK: Uint128 = Uint128::new(1_000_000_000000);
+    const AMOUNT: Uint128 = Uint128::new(1_000000);
+    const ZERO: Uint128 = Uint128::zero();
+    const DZERO: Decimal = Decimal::zero();
+
+    // Computing ask
+    assert_eq!(
+        compute_swap(ZERO, ZERO, ZERO, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_swap(ZERO, ZERO, AMOUNT, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_swap(ZERO, ASK, ZERO, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_swap(ZERO, ASK, AMOUNT, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_swap(OFFER, ZERO, ZERO, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_swap(OFFER, ZERO, AMOUNT, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_swap(OFFER, ASK, ZERO, DZERO).unwrap_err(),
+        StdError::generic_err("Swap amount must not be zero")
+    );
+    compute_swap(OFFER, ASK, AMOUNT, DZERO).unwrap();
+
+    // Computing offer
+    assert_eq!(
+        compute_offer_amount(ZERO, ZERO, ZERO, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_offer_amount(ZERO, ZERO, AMOUNT, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_offer_amount(ZERO, ASK, ZERO, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_offer_amount(ZERO, ASK, AMOUNT, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_offer_amount(OFFER, ZERO, ZERO, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_offer_amount(OFFER, ZERO, AMOUNT, DZERO).unwrap_err(),
+        StdError::generic_err("One of the pools is empty")
+    );
+    assert_eq!(
+        compute_offer_amount(OFFER, ASK, ZERO, DZERO).unwrap_err(),
+        StdError::generic_err("Swap amount must not be zero")
+    );
+    compute_offer_amount(OFFER, ASK, AMOUNT, DZERO).unwrap();
+}

--- a/contracts/pair_xyk_sale_tax/src/testing.rs
+++ b/contracts/pair_xyk_sale_tax/src/testing.rs
@@ -392,7 +392,7 @@ fn provide_liquidity() {
     assert_eq!(
         res,
         ContractError::Std(StdError::generic_err(
-            "Native token balance mismatch between the argument and the transferred",
+            "Native token balance mismatch between the argument (50000000000000000000uusd) and the transferred (100000000000000000000uusd)",
         ))
     );
 

--- a/contracts/pair_xyk_sale_tax/tests/integration.rs
+++ b/contracts/pair_xyk_sale_tax/tests/integration.rs
@@ -12,7 +12,7 @@ use astroport::pair::{
     ConfigResponse, CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
     TWAP_PRECISION,
 };
-use astroport::pair_xyk_sale_tax::{SaleTaxConfigUpdates, SaleTaxInitParams, TaxConfigUnchecked};
+use astroport::pair_xyk_sale_tax::{SaleTaxConfigUpdates, SaleTaxInitParams, TaxConfigsUnchecked};
 use astroport::token::InstantiateMsg as TokenInstantiateMsg;
 use astroport_mocks::cw_multi_test::{App, BasicApp, ContractWrapper, Executor};
 use astroport_mocks::{astroport_address, MockGeneratorBuilder, MockXykPairBuilder};
@@ -855,10 +855,7 @@ fn asset_balances_tracking_works_correctly() {
         pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
         init_params: Some(
             to_binary(&SaleTaxInitParams {
-                tax_config: TaxConfigUnchecked {
-                    tax_denom: "test1".to_string(),
-                    ..Default::default()
-                },
+                tax_configs: TaxConfigsUnchecked::new(),
                 ..Default::default()
             })
             .unwrap(),
@@ -1067,10 +1064,7 @@ fn asset_balances_tracking_works_correctly() {
         init_params: Some(
             to_binary(&SaleTaxInitParams {
                 track_asset_balances: true,
-                tax_config: TaxConfigUnchecked {
-                    tax_rate: Decimal::zero(),
-                    ..Default::default()
-                },
+                tax_configs: TaxConfigsUnchecked::new(),
             })
             .unwrap(),
         ),

--- a/contracts/pair_xyk_sale_tax/tests/integration.rs
+++ b/contracts/pair_xyk_sale_tax/tests/integration.rs
@@ -1,0 +1,1653 @@
+#![cfg(not(tarpaulin_include))]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use astroport::asset::{native_asset_info, Asset, AssetInfo, AssetInfoExt, PairInfo};
+use astroport::factory::{
+    ExecuteMsg as FactoryExecuteMsg, InstantiateMsg as FactoryInstantiateMsg, PairConfig, PairType,
+    QueryMsg as FactoryQueryMsg,
+};
+use astroport::pair::{
+    ConfigResponse, CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
+    XYKPoolConfig, XYKPoolParams, XYKPoolUpdateParams, TWAP_PRECISION,
+};
+use astroport::token::InstantiateMsg as TokenInstantiateMsg;
+use astroport_mocks::cw_multi_test::{App, BasicApp, ContractWrapper, Executor};
+use astroport_mocks::{astroport_address, MockGeneratorBuilder, MockXykPairBuilder};
+use astroport_pair_xyk_sale_tax::error::ContractError;
+use cosmwasm_std::{attr, to_binary, Addr, Coin, Decimal, Uint128};
+use cw20::{BalanceResponse, Cw20Coin, Cw20ExecuteMsg, Cw20QueryMsg, MinterResponse};
+
+const OWNER: &str = "owner";
+
+fn mock_app(owner: Addr, coins: Vec<Coin>) -> App {
+    App::new(|router, _, storage| {
+        // initialization moved to App construction
+        router.bank.init_balance(storage, &owner, coins).unwrap()
+    })
+}
+
+fn store_token_code(app: &mut App) -> u64 {
+    let astro_token_contract = Box::new(ContractWrapper::new_with_empty(
+        astroport_token::contract::execute,
+        astroport_token::contract::instantiate,
+        astroport_token::contract::query,
+    ));
+
+    app.store_code(astro_token_contract)
+}
+
+fn store_pair_code(app: &mut App) -> u64 {
+    let pair_contract = Box::new(
+        ContractWrapper::new_with_empty(
+            astroport_pair_xyk_sale_tax::contract::execute,
+            astroport_pair_xyk_sale_tax::contract::instantiate,
+            astroport_pair_xyk_sale_tax::contract::query,
+        )
+        .with_reply_empty(astroport_pair_xyk_sale_tax::contract::reply),
+    );
+
+    app.store_code(pair_contract)
+}
+
+fn store_factory_code(app: &mut App) -> u64 {
+    let factory_contract = Box::new(
+        ContractWrapper::new_with_empty(
+            astroport_factory::contract::execute,
+            astroport_factory::contract::instantiate,
+            astroport_factory::contract::query,
+        )
+        .with_reply_empty(astroport_factory::contract::reply),
+    );
+
+    app.store_code(factory_contract)
+}
+
+fn instantiate_pair(mut router: &mut App, owner: &Addr) -> Addr {
+    let token_contract_code_id = store_token_code(&mut router);
+
+    let pair_contract_code_id = store_pair_code(&mut router);
+    let factory_code_id = store_factory_code(&mut router);
+
+    let init_msg = FactoryInstantiateMsg {
+        fee_address: None,
+        pair_configs: vec![PairConfig {
+            code_id: pair_contract_code_id,
+            maker_fee_bps: 0,
+            pair_type: PairType::Xyk {},
+            total_fee_bps: 0,
+            is_disabled: false,
+            is_generator_disabled: false,
+        }],
+        token_code_id: token_contract_code_id,
+        generator_address: Some(String::from("generator")),
+        owner: owner.to_string(),
+        whitelist_code_id: 234u64,
+        coin_registry_address: "coin_registry".to_string(),
+    };
+
+    let factory_instance = router
+        .instantiate_contract(
+            factory_code_id,
+            owner.clone(),
+            &init_msg,
+            &[],
+            "FACTORY",
+            None,
+        )
+        .unwrap();
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "uluna".to_string(),
+            },
+        ],
+        token_code_id: token_contract_code_id,
+        factory_addr: factory_instance.to_string(),
+        init_params: None,
+    };
+
+    let pair = router
+        .instantiate_contract(
+            pair_contract_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("PAIR"),
+            None,
+        )
+        .unwrap();
+
+    let res: PairInfo = router
+        .wrap()
+        .query_wasm_smart(pair.clone(), &QueryMsg::Pair {})
+        .unwrap();
+    assert_eq!("contract1", res.contract_addr);
+    assert_eq!("contract2", res.liquidity_token);
+
+    pair
+}
+
+#[test]
+fn test_provide_and_withdraw_liquidity() {
+    let owner = Addr::unchecked("owner");
+    let alice_address = Addr::unchecked("alice");
+    let mut router = mock_app(
+        owner.clone(),
+        vec![
+            Coin {
+                denom: "uusd".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+            Coin {
+                denom: "uluna".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+            Coin {
+                denom: "cny".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+        ],
+    );
+
+    // Set Alice's balances
+    router
+        .send_tokens(
+            owner.clone(),
+            alice_address.clone(),
+            &[
+                Coin {
+                    denom: "uusd".to_string(),
+                    amount: Uint128::new(233_000_000u128),
+                },
+                Coin {
+                    denom: "uluna".to_string(),
+                    amount: Uint128::new(2_00_000_000u128),
+                },
+                Coin {
+                    denom: "cny".to_string(),
+                    amount: Uint128::from(100_000_000u128),
+                },
+            ],
+        )
+        .unwrap();
+
+    // Init pair
+    let pair_instance = instantiate_pair(&mut router, &owner);
+
+    let res: PairInfo = router
+        .wrap()
+        .query_wasm_smart(pair_instance.to_string(), &QueryMsg::Pair {})
+        .unwrap();
+    let lp_token = res.liquidity_token;
+
+    assert_eq!(
+        res.asset_infos,
+        [
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "uluna".to_string(),
+            },
+        ],
+    );
+
+    // Provide liquidity
+    let (msg, coins) = provide_liquidity_msg(
+        Uint128::new(100_000_000),
+        Uint128::new(100_000_000),
+        None,
+        None,
+    );
+    let res = router
+        .execute_contract(alice_address.clone(), pair_instance.clone(), &msg, &coins)
+        .unwrap();
+
+    assert_eq!(
+        res.events[1].attributes[1],
+        attr("action", "provide_liquidity")
+    );
+    assert_eq!(res.events[1].attributes[3], attr("receiver", "alice"),);
+    assert_eq!(
+        res.events[1].attributes[4],
+        attr("assets", "100000000uusd, 100000000uluna")
+    );
+    assert_eq!(
+        res.events[1].attributes[5],
+        attr("share", 99999000u128.to_string())
+    );
+    assert_eq!(res.events[3].attributes[1], attr("action", "mint"));
+    assert_eq!(res.events[3].attributes[2], attr("to", "contract1"));
+    assert_eq!(
+        res.events[3].attributes[3],
+        attr("amount", 1000.to_string())
+    );
+    assert_eq!(res.events[5].attributes[1], attr("action", "mint"));
+    assert_eq!(res.events[5].attributes[2], attr("to", "alice"));
+    assert_eq!(
+        res.events[5].attributes[3],
+        attr("amount", 99999000.to_string())
+    );
+
+    // Provide liquidity for receiver
+    let (msg, coins) = provide_liquidity_msg(
+        Uint128::new(100),
+        Uint128::new(100),
+        Some("bob".to_string()),
+        None,
+    );
+    let res = router
+        .execute_contract(alice_address.clone(), pair_instance.clone(), &msg, &coins)
+        .unwrap();
+
+    assert_eq!(
+        res.events[1].attributes[1],
+        attr("action", "provide_liquidity")
+    );
+    assert_eq!(res.events[1].attributes[3], attr("receiver", "bob"),);
+    assert_eq!(
+        res.events[1].attributes[4],
+        attr("assets", "100uusd, 100uluna")
+    );
+    assert_eq!(
+        res.events[1].attributes[5],
+        attr("share", 100u128.to_string())
+    );
+    assert_eq!(res.events[3].attributes[1], attr("action", "mint"));
+    assert_eq!(res.events[3].attributes[2], attr("to", "bob"));
+    assert_eq!(res.events[3].attributes[3], attr("amount", 100.to_string()));
+
+    // Checking withdraw liquidity
+    let token_contract_code_id = store_token_code(&mut router);
+    let foo_token = router
+        .instantiate_contract(
+            token_contract_code_id,
+            owner.clone(),
+            &astroport::token::InstantiateMsg {
+                name: "Foo token".to_string(),
+                symbol: "FOO".to_string(),
+                decimals: 6,
+                initial_balances: vec![Cw20Coin {
+                    address: alice_address.to_string(),
+                    amount: Uint128::from(1000000000u128),
+                }],
+                mint: None,
+                marketing: None,
+            },
+            &[],
+            String::from("FOO"),
+            None,
+        )
+        .unwrap();
+
+    let msg = Cw20ExecuteMsg::Send {
+        contract: pair_instance.to_string(),
+        amount: Uint128::from(50u8),
+        msg: to_binary(&Cw20HookMsg::WithdrawLiquidity { assets: vec![] }).unwrap(),
+    };
+    // Try to send withdraw liquidity with FOO token
+    let err = router
+        .execute_contract(alice_address.clone(), foo_token.clone(), &msg, &[])
+        .unwrap_err();
+    assert_eq!(err.root_cause().to_string(), "Unauthorized");
+    // Withdraw with LP token is successful
+    router
+        .execute_contract(alice_address.clone(), lp_token.clone(), &msg, &[])
+        .unwrap();
+
+    let err = router
+        .execute_contract(
+            alice_address.clone(),
+            pair_instance.clone(),
+            &ExecuteMsg::Swap {
+                offer_asset: Asset {
+                    info: AssetInfo::NativeToken {
+                        denom: "cny".to_string(),
+                    },
+                    amount: Uint128::from(10u8),
+                },
+                ask_asset_info: None,
+                belief_price: None,
+                max_spread: None,
+                to: None,
+            },
+            &[Coin {
+                denom: "cny".to_string(),
+                amount: Uint128::from(10u8),
+            }],
+        )
+        .unwrap_err();
+    assert_eq!(
+        err.root_cause().to_string(),
+        "Asset mismatch between the requested and the stored asset in contract"
+    );
+
+    // Check pair config
+    let config: ConfigResponse = router
+        .wrap()
+        .query_wasm_smart(pair_instance.to_string(), &QueryMsg::Config {})
+        .unwrap();
+    assert_eq!(
+        config.clone(),
+        ConfigResponse {
+            block_time_last: router.block_info().time.seconds(),
+            params: Some(
+                to_binary(&XYKPoolConfig {
+                    track_asset_balances: false
+                })
+                .unwrap()
+            ),
+            owner,
+            factory_addr: config.factory_addr
+        }
+    )
+}
+
+fn provide_liquidity_msg(
+    uusd_amount: Uint128,
+    uluna_amount: Uint128,
+    receiver: Option<String>,
+    slippage_tolerance: Option<Decimal>,
+) -> (ExecuteMsg, [Coin; 2]) {
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: uusd_amount.clone(),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uluna".to_string(),
+                },
+                amount: uluna_amount.clone(),
+            },
+        ],
+        slippage_tolerance: Option::from(slippage_tolerance),
+        auto_stake: None,
+        receiver,
+    };
+
+    let coins = [
+        Coin {
+            denom: "uluna".to_string(),
+            amount: uluna_amount.clone(),
+        },
+        Coin {
+            denom: "uusd".to_string(),
+            amount: uusd_amount.clone(),
+        },
+    ];
+
+    (msg, coins)
+}
+
+#[test]
+fn test_compatibility_of_tokens_with_different_precision() {
+    let owner = Addr::unchecked(OWNER);
+
+    let mut app = mock_app(
+        owner.clone(),
+        vec![
+            Coin {
+                denom: "uusd".to_string(),
+                amount: Uint128::new(100_000_000_000000u128),
+            },
+            Coin {
+                denom: "uluna".to_string(),
+                amount: Uint128::new(100_000_000_000000u128),
+            },
+        ],
+    );
+
+    let token_code_id = store_token_code(&mut app);
+
+    let x_amount = Uint128::new(1000000_00000);
+    let y_amount = Uint128::new(1000000_0000000);
+    let x_offer = Uint128::new(1_00000);
+    let y_expected_return = Uint128::new(1_0000000);
+
+    let token_name = "Xtoken";
+
+    let init_msg = TokenInstantiateMsg {
+        name: token_name.to_string(),
+        symbol: token_name.to_string(),
+        decimals: 5,
+        initial_balances: vec![Cw20Coin {
+            address: OWNER.to_string(),
+            amount: x_amount + x_offer,
+        }],
+        mint: Some(MinterResponse {
+            minter: String::from(OWNER),
+            cap: None,
+        }),
+        marketing: None,
+    };
+
+    let token_x_instance = app
+        .instantiate_contract(
+            token_code_id,
+            owner.clone(),
+            &init_msg,
+            &[],
+            token_name,
+            None,
+        )
+        .unwrap();
+
+    let token_name = "Ytoken";
+
+    let init_msg = TokenInstantiateMsg {
+        name: token_name.to_string(),
+        symbol: token_name.to_string(),
+        decimals: 7,
+        initial_balances: vec![Cw20Coin {
+            address: OWNER.to_string(),
+            amount: y_amount,
+        }],
+        mint: Some(MinterResponse {
+            minter: String::from(OWNER),
+            cap: None,
+        }),
+        marketing: None,
+    };
+
+    let token_y_instance = app
+        .instantiate_contract(
+            token_code_id,
+            owner.clone(),
+            &init_msg,
+            &[],
+            token_name,
+            None,
+        )
+        .unwrap();
+
+    let pair_code_id = store_pair_code(&mut app);
+    let factory_code_id = store_factory_code(&mut app);
+
+    let init_msg = FactoryInstantiateMsg {
+        fee_address: None,
+        pair_configs: vec![PairConfig {
+            code_id: pair_code_id,
+            maker_fee_bps: 0,
+            pair_type: PairType::Xyk {},
+            total_fee_bps: 0,
+            is_disabled: false,
+            is_generator_disabled: false,
+        }],
+        token_code_id,
+        generator_address: Some(String::from("generator")),
+        owner: owner.to_string(),
+        whitelist_code_id: 234u64,
+        coin_registry_address: "coin_registry".to_string(),
+    };
+
+    let factory_instance = app
+        .instantiate_contract(
+            factory_code_id,
+            owner.clone(),
+            &init_msg,
+            &[],
+            "FACTORY",
+            None,
+        )
+        .unwrap();
+
+    let msg = FactoryExecuteMsg::CreatePair {
+        asset_infos: vec![
+            AssetInfo::Token {
+                contract_addr: token_x_instance.clone(),
+            },
+            AssetInfo::Token {
+                contract_addr: token_y_instance.clone(),
+            },
+        ],
+        pair_type: PairType::Xyk {},
+        init_params: None,
+    };
+
+    app.execute_contract(owner.clone(), factory_instance.clone(), &msg, &[])
+        .unwrap();
+
+    let msg = FactoryQueryMsg::Pair {
+        asset_infos: vec![
+            AssetInfo::Token {
+                contract_addr: token_x_instance.clone(),
+            },
+            AssetInfo::Token {
+                contract_addr: token_y_instance.clone(),
+            },
+        ],
+    };
+
+    let res: PairInfo = app
+        .wrap()
+        .query_wasm_smart(&factory_instance, &msg)
+        .unwrap();
+
+    let pair_instance = res.contract_addr;
+
+    let msg = Cw20ExecuteMsg::IncreaseAllowance {
+        spender: pair_instance.to_string(),
+        expires: None,
+        amount: x_amount + x_offer,
+    };
+
+    app.execute_contract(owner.clone(), token_x_instance.clone(), &msg, &[])
+        .unwrap();
+
+    let msg = Cw20ExecuteMsg::IncreaseAllowance {
+        spender: pair_instance.to_string(),
+        expires: None,
+        amount: y_amount,
+    };
+
+    app.execute_contract(owner.clone(), token_y_instance.clone(), &msg, &[])
+        .unwrap();
+
+    let user = Addr::unchecked("user");
+
+    let swap_msg = Cw20ExecuteMsg::Send {
+        contract: pair_instance.to_string(),
+        msg: to_binary(&Cw20HookMsg::Swap {
+            ask_asset_info: None,
+            belief_price: None,
+            max_spread: None,
+            to: Some(user.to_string()),
+        })
+        .unwrap(),
+        amount: x_offer,
+    };
+
+    let err = app
+        .execute_contract(owner.clone(), token_x_instance.clone(), &swap_msg, &[])
+        .unwrap_err();
+    assert_eq!(
+        "Generic error: One of the pools is empty",
+        err.root_cause().to_string()
+    );
+
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: token_x_instance.clone(),
+                },
+                amount: x_amount,
+            },
+            Asset {
+                info: AssetInfo::Token {
+                    contract_addr: token_y_instance.clone(),
+                },
+                amount: y_amount,
+            },
+        ],
+        slippage_tolerance: None,
+        auto_stake: None,
+        receiver: None,
+    };
+
+    app.execute_contract(owner.clone(), pair_instance.clone(), &msg, &[])
+        .unwrap();
+
+    let user = Addr::unchecked("user");
+
+    let swap_msg = Cw20ExecuteMsg::Send {
+        contract: pair_instance.to_string(),
+        msg: to_binary(&Cw20HookMsg::Swap {
+            ask_asset_info: None,
+            belief_price: None,
+            max_spread: None,
+            to: Some(user.to_string()),
+        })
+        .unwrap(),
+        amount: x_offer,
+    };
+
+    // try to swap after provide liquidity
+    app.execute_contract(owner.clone(), token_x_instance.clone(), &swap_msg, &[])
+        .unwrap();
+
+    let msg = Cw20QueryMsg::Balance {
+        address: user.to_string(),
+    };
+
+    let res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(&token_y_instance, &msg)
+        .unwrap();
+
+    let acceptable_spread_amount = Uint128::new(10);
+
+    assert_eq!(res.balance, y_expected_return - acceptable_spread_amount);
+}
+
+#[test]
+fn test_if_twap_is_calculated_correctly_when_pool_idles() {
+    let owner = Addr::unchecked("owner");
+    let user1 = Addr::unchecked("user1");
+
+    let mut app = mock_app(
+        owner.clone(),
+        vec![
+            Coin {
+                denom: "uusd".to_string(),
+                amount: Uint128::new(100_000_000_000000u128),
+            },
+            Coin {
+                denom: "uluna".to_string(),
+                amount: Uint128::new(100_000_000_000000u128),
+            },
+        ],
+    );
+
+    // Set Alice's balances
+    app.send_tokens(
+        owner.clone(),
+        user1.clone(),
+        &[
+            Coin {
+                denom: "uusd".to_string(),
+                amount: Uint128::new(4000000_000000),
+            },
+            Coin {
+                denom: "uluna".to_string(),
+                amount: Uint128::new(2000000_000000),
+            },
+        ],
+    )
+    .unwrap();
+
+    // Instantiate pair
+    let pair_instance = instantiate_pair(&mut app, &user1);
+
+    // Provide liquidity, accumulators are empty
+    let (msg, coins) = provide_liquidity_msg(
+        Uint128::new(1000000_000000),
+        Uint128::new(1000000_000000),
+        None,
+        Option::from(Decimal::one()),
+    );
+    app.execute_contract(user1.clone(), pair_instance.clone(), &msg, &coins)
+        .unwrap();
+
+    const BLOCKS_PER_DAY: u64 = 17280;
+    const ELAPSED_SECONDS: u64 = BLOCKS_PER_DAY * 5;
+
+    // A day later
+    app.update_block(|b| {
+        b.height += BLOCKS_PER_DAY;
+        b.time = b.time.plus_seconds(ELAPSED_SECONDS);
+    });
+
+    // Provide liquidity, accumulators firstly filled with the same prices
+    let (msg, coins) = provide_liquidity_msg(
+        Uint128::new(2000000_000000),
+        Uint128::new(1000000_000000),
+        None,
+        Some(Decimal::percent(50)),
+    );
+    app.execute_contract(user1.clone(), pair_instance.clone(), &msg, &coins)
+        .unwrap();
+
+    // Get current twap accumulator values
+    let msg = QueryMsg::CumulativePrices {};
+    let cpr_old: CumulativePricesResponse =
+        app.wrap().query_wasm_smart(&pair_instance, &msg).unwrap();
+
+    // A day later
+    app.update_block(|b| {
+        b.height += BLOCKS_PER_DAY;
+        b.time = b.time.plus_seconds(ELAPSED_SECONDS);
+    });
+
+    // Get current cumulative price values; they should have been updated by the query method with new 2/1 ratio
+    let msg = QueryMsg::CumulativePrices {};
+    let cpr_new: CumulativePricesResponse =
+        app.wrap().query_wasm_smart(&pair_instance, &msg).unwrap();
+
+    let twap0 = cpr_new.cumulative_prices[0].2 - cpr_old.cumulative_prices[0].2;
+    let twap1 = cpr_new.cumulative_prices[1].2 - cpr_old.cumulative_prices[1].2;
+
+    // Prices weren't changed for the last day, uusd amount in pool = 3000000_000000, uluna = 2000000_000000
+    // In accumulators we don't have any precision so we rely on elapsed time so we don't need to consider it
+    let price_precision = Uint128::from(10u128.pow(TWAP_PRECISION.into()));
+    assert_eq!(twap0 / price_precision, Uint128::new(57600)); // 0.666666 * ELAPSED_SECONDS (86400)
+    assert_eq!(twap1 / price_precision, Uint128::new(129600)); //   1.5 * ELAPSED_SECONDS
+}
+
+#[test]
+fn create_pair_with_same_assets() {
+    let owner = Addr::unchecked("owner");
+    let mut router = mock_app(
+        owner.clone(),
+        vec![
+            Coin {
+                denom: "uusd".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+            Coin {
+                denom: "uluna".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+        ],
+    );
+
+    let token_contract_code_id = store_token_code(&mut router);
+    let pair_contract_code_id = store_pair_code(&mut router);
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+        ],
+        token_code_id: token_contract_code_id,
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let resp = router
+        .instantiate_contract(
+            pair_contract_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("PAIR"),
+            None,
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        resp.root_cause().to_string(),
+        "Doubling assets in asset infos"
+    )
+}
+
+#[test]
+fn wrong_number_of_assets() {
+    let owner = Addr::unchecked("owner");
+    let mut router = mock_app(owner.clone(), vec![]);
+
+    let pair_contract_code_id = store_pair_code(&mut router);
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![AssetInfo::NativeToken {
+            denom: "uusd".to_string(),
+        }],
+        token_code_id: 123,
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let err = router
+        .instantiate_contract(
+            pair_contract_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("PAIR"),
+            None,
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err.root_cause().to_string(),
+        "Generic error: asset_infos must contain exactly two elements"
+    );
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            native_asset_info("uusd".to_string()),
+            native_asset_info("dust".to_string()),
+            native_asset_info("stone".to_string()),
+        ],
+        token_code_id: 123,
+        factory_addr: String::from("factory"),
+        init_params: None,
+    };
+
+    let err = router
+        .instantiate_contract(
+            pair_contract_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("PAIR"),
+            None,
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err.root_cause().to_string(),
+        "Generic error: asset_infos must contain exactly two elements"
+    );
+}
+
+#[test]
+fn asset_balances_tracking_works_correctly() {
+    let owner = Addr::unchecked("owner");
+    let mut app = mock_app(
+        owner.clone(),
+        vec![
+            Coin {
+                denom: "test1".to_owned(),
+                amount: Uint128::new(5_000000),
+            },
+            Coin {
+                denom: "test2".to_owned(),
+                amount: Uint128::new(5_000000),
+            },
+            Coin {
+                denom: "uluna".to_owned(),
+                amount: Uint128::new(1000_000000),
+            },
+            Coin {
+                denom: "uusd".to_owned(),
+                amount: Uint128::new(1000_000000),
+            },
+        ],
+    );
+    let token_code_id = store_token_code(&mut app);
+    let pair_code_id = store_pair_code(&mut app);
+    let factory_code_id = store_factory_code(&mut app);
+
+    let init_msg = FactoryInstantiateMsg {
+        fee_address: None,
+        pair_configs: vec![PairConfig {
+            code_id: pair_code_id,
+            maker_fee_bps: 0,
+            pair_type: PairType::Xyk {},
+            total_fee_bps: 0,
+            is_disabled: false,
+            is_generator_disabled: false,
+        }],
+        token_code_id,
+        generator_address: Some(String::from("generator")),
+        owner: owner.to_string(),
+        whitelist_code_id: 234u64,
+        coin_registry_address: "coin_registry".to_string(),
+    };
+
+    let factory_instance = app
+        .instantiate_contract(
+            factory_code_id,
+            owner.clone(),
+            &init_msg,
+            &[],
+            "FACTORY",
+            None,
+        )
+        .unwrap();
+
+    // Instantiate pair without asset balances tracking
+    let msg = FactoryExecuteMsg::CreatePair {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "test1".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "test2".to_string(),
+            },
+        ],
+        pair_type: PairType::Xyk {},
+        init_params: None,
+    };
+
+    app.execute_contract(owner.clone(), factory_instance.clone(), &msg, &[])
+        .unwrap();
+
+    let msg = FactoryQueryMsg::Pair {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "test1".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "test2".to_string(),
+            },
+        ],
+    };
+
+    let res: PairInfo = app
+        .wrap()
+        .query_wasm_smart(&factory_instance, &msg)
+        .unwrap();
+
+    let pair_instance = res.contract_addr;
+
+    // Check that asset balances are not tracked
+    // The query AssetBalanceAt returns None for this case
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "test1".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.is_none());
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "test2".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.is_none());
+
+    // Enable asset balances tracking
+    let msg = ExecuteMsg::UpdateConfig {
+        params: to_binary(&XYKPoolUpdateParams::EnableAssetBalancesTracking).unwrap(),
+    };
+    app.execute_contract(owner.clone(), pair_instance.clone(), &msg, &[])
+        .unwrap();
+
+    // Check that asset balances were not tracked before this was enabled
+    // The query AssetBalanceAt returns None for this case
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "test1".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.is_none());
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "test2".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.is_none());
+
+    // Check that asset balances had zero balances before next block upon tracking enabing
+    app.update_block(|b| b.height += 1);
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "test1".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.unwrap().is_zero());
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "test2".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.unwrap().is_zero());
+
+    // Provide liquidity
+    let msg = ExecuteMsg::ProvideLiquidity {
+        assets: vec![
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "test1".to_string(),
+                },
+                amount: Uint128::new(5_000000),
+            },
+            Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "test2".to_string(),
+                },
+                amount: Uint128::new(5_000000),
+            },
+        ],
+        slippage_tolerance: None,
+        auto_stake: None,
+        receiver: None,
+    };
+
+    let send_funds = [
+        Coin {
+            denom: "test1".to_string(),
+            amount: Uint128::new(5_000000),
+        },
+        Coin {
+            denom: "test2".to_string(),
+            amount: Uint128::new(5_000000),
+        },
+    ];
+
+    app.execute_contract(owner.clone(), pair_instance.clone(), &msg, &send_funds)
+        .unwrap();
+
+    // Check that asset balances changed after providing liqudity
+    app.update_block(|b| b.height += 1);
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "test1".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.unwrap(), Uint128::new(5_000000));
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "test2".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.unwrap(), Uint128::new(5_000000));
+
+    // Instantiate new pair with asset balances tracking starting from instantiation
+    let msg = FactoryExecuteMsg::CreatePair {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uluna".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+        ],
+        pair_type: PairType::Xyk {},
+        init_params: Some(
+            to_binary(&XYKPoolParams {
+                track_asset_balances: Some(true),
+            })
+            .unwrap(),
+        ),
+    };
+
+    app.execute_contract(owner.clone(), factory_instance.clone(), &msg, &[])
+        .unwrap();
+
+    let msg = FactoryQueryMsg::Pair {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uluna".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+        ],
+    };
+
+    let res: PairInfo = app
+        .wrap()
+        .query_wasm_smart(&factory_instance, &msg)
+        .unwrap();
+
+    let pair_instance = res.contract_addr;
+    let lp_token_address = res.liquidity_token;
+
+    // Check that asset balances were not tracked before instantiation
+    // The query AssetBalanceAt returns None for this case
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uluna".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.is_none());
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uusd".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.is_none());
+
+    // Check that enabling asset balances tracking can not be done if it is already enabled
+    let msg = ExecuteMsg::UpdateConfig {
+        params: to_binary(&XYKPoolUpdateParams::EnableAssetBalancesTracking).unwrap(),
+    };
+    assert_eq!(
+        app.execute_contract(owner.clone(), pair_instance.clone(), &msg, &[])
+            .unwrap_err()
+            .downcast_ref::<ContractError>()
+            .unwrap(),
+        &ContractError::AssetBalancesTrackingIsAlreadyEnabled {}
+    );
+
+    // Check that asset balances were not tracked before instantiation
+    // The query AssetBalanceAt returns None for this case
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uluna".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.is_none());
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uusd".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.is_none());
+
+    // Check that asset balances had zero balances before next block upon instantiation
+    app.update_block(|b| b.height += 1);
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uluna".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.unwrap().is_zero());
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uusd".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert!(res.unwrap().is_zero());
+
+    // Provide liquidity
+    let (msg, send_funds) = provide_liquidity_msg(
+        Uint128::new(999_000000),
+        Uint128::new(1000_000000),
+        None,
+        None,
+    );
+    app.execute_contract(owner.clone(), pair_instance.clone(), &msg, &send_funds)
+        .unwrap();
+
+    let msg = Cw20QueryMsg::Balance {
+        address: owner.to_string(),
+    };
+    let owner_lp_balance: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(&lp_token_address, &msg)
+        .unwrap();
+    assert_eq!(owner_lp_balance.balance, Uint128::new(999498874));
+
+    // Check that asset balances changed after providing liqudity
+    app.update_block(|b| b.height += 1);
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uluna".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.unwrap(), Uint128::new(1000_000000));
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uusd".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.unwrap(), Uint128::new(999_000000));
+
+    // Swap
+
+    let msg = ExecuteMsg::Swap {
+        offer_asset: Asset {
+            info: AssetInfo::NativeToken {
+                denom: "uusd".to_owned(),
+            },
+            amount: Uint128::new(1_000000),
+        },
+        ask_asset_info: None,
+        belief_price: None,
+        max_spread: None,
+        to: None,
+    };
+    let send_funds = vec![Coin {
+        denom: "uusd".to_owned(),
+        amount: Uint128::new(1_000000),
+    }];
+    app.execute_contract(owner.clone(), pair_instance.clone(), &msg, &send_funds)
+        .unwrap();
+
+    // Check that asset balances changed after swaping
+    app.update_block(|b| b.height += 1);
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uluna".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.unwrap(), Uint128::new(999_000000));
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uusd".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.unwrap(), Uint128::new(1000_000000));
+
+    // Withdraw liqudity
+    let msg = Cw20ExecuteMsg::Send {
+        contract: pair_instance.to_string(),
+        amount: Uint128::new(500_000000),
+        msg: to_binary(&Cw20HookMsg::WithdrawLiquidity { assets: vec![] }).unwrap(),
+    };
+
+    app.execute_contract(owner.clone(), lp_token_address, &msg, &[])
+        .unwrap();
+
+    // Check that asset balances changed after withdrawing
+    app.update_block(|b| b.height += 1);
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uluna".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.unwrap(), Uint128::new(499_250063));
+
+    let res: Option<Uint128> = app
+        .wrap()
+        .query_wasm_smart(
+            &pair_instance,
+            &QueryMsg::AssetBalanceAt {
+                asset_info: AssetInfo::NativeToken {
+                    denom: "uusd".to_owned(),
+                },
+                block_height: app.block_info().height.into(),
+            },
+        )
+        .unwrap();
+    assert_eq!(res.unwrap(), Uint128::new(499_749812));
+}
+
+#[test]
+fn update_pair_config() {
+    let owner = Addr::unchecked(OWNER);
+    let mut router = mock_app(
+        owner.clone(),
+        vec![
+            Coin {
+                denom: "uusd".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+            Coin {
+                denom: "uluna".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+        ],
+    );
+
+    let token_contract_code_id = store_token_code(&mut router);
+    let pair_contract_code_id = store_pair_code(&mut router);
+
+    let factory_code_id = store_factory_code(&mut router);
+
+    let init_msg = FactoryInstantiateMsg {
+        fee_address: None,
+        pair_configs: vec![],
+        token_code_id: token_contract_code_id,
+        generator_address: Some(String::from("generator")),
+        owner: owner.to_string(),
+        whitelist_code_id: 234u64,
+        coin_registry_address: "coin_registry".to_string(),
+    };
+
+    let factory_instance = router
+        .instantiate_contract(
+            factory_code_id,
+            owner.clone(),
+            &init_msg,
+            &[],
+            "FACTORY",
+            None,
+        )
+        .unwrap();
+
+    let msg = InstantiateMsg {
+        asset_infos: vec![
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "uluna".to_string(),
+            },
+        ],
+        token_code_id: token_contract_code_id,
+        factory_addr: factory_instance.to_string(),
+        init_params: None,
+    };
+
+    let pair = router
+        .instantiate_contract(
+            pair_contract_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("PAIR"),
+            None,
+        )
+        .unwrap();
+
+    let res: ConfigResponse = router
+        .wrap()
+        .query_wasm_smart(pair.clone(), &QueryMsg::Config {})
+        .unwrap();
+
+    assert_eq!(
+        res,
+        ConfigResponse {
+            block_time_last: 0,
+            params: Some(
+                to_binary(&XYKPoolConfig {
+                    track_asset_balances: false
+                })
+                .unwrap()
+            ),
+            owner: Addr::unchecked("owner"),
+            factory_addr: Addr::unchecked("contract0")
+        }
+    );
+
+    let msg = ExecuteMsg::UpdateConfig {
+        params: to_binary(&XYKPoolUpdateParams::EnableAssetBalancesTracking).unwrap(),
+    };
+    assert_eq!(
+        router
+            .execute_contract(
+                Addr::unchecked("not_owner").clone(),
+                pair.clone(),
+                &msg,
+                &[]
+            )
+            .unwrap_err()
+            .downcast_ref::<ContractError>()
+            .unwrap(),
+        &ContractError::Unauthorized {}
+    );
+
+    router
+        .execute_contract(owner.clone(), pair.clone(), &msg, &[])
+        .unwrap();
+
+    let res: ConfigResponse = router
+        .wrap()
+        .query_wasm_smart(pair.clone(), &QueryMsg::Config {})
+        .unwrap();
+    assert_eq!(
+        res,
+        ConfigResponse {
+            block_time_last: 0,
+            params: Some(
+                to_binary(&XYKPoolConfig {
+                    track_asset_balances: true
+                })
+                .unwrap()
+            ),
+            owner: Addr::unchecked("owner"),
+            factory_addr: Addr::unchecked("contract0")
+        }
+    );
+}
+
+#[test]
+fn provide_liquidity_with_autostaking_to_generator() {
+    let astroport = astroport_address();
+
+    let app = Rc::new(RefCell::new(BasicApp::new(|router, _, storage| {
+        router
+            .bank
+            .init_balance(
+                storage,
+                &astroport,
+                vec![Coin {
+                    denom: "ustake".to_owned(),
+                    amount: Uint128::new(1_000_000_000000),
+                }],
+            )
+            .unwrap();
+    })));
+
+    let generator = MockGeneratorBuilder::new(&app).instantiate();
+
+    let factory = generator.factory();
+
+    let astro_token_info = generator.astro_token_info();
+    let ustake = native_asset_info("ustake".to_owned());
+
+    let pair = MockXykPairBuilder::new(&app)
+        .with_factory(&factory)
+        .with_asset(&astro_token_info)
+        .with_asset(&ustake)
+        .instantiate();
+
+    pair.mint_allow_provide_and_stake(
+        &astroport,
+        &[
+            astro_token_info.with_balance(1_000_000000u128),
+            ustake.with_balance(1_000_000000u128),
+        ],
+    );
+
+    assert_eq!(pair.lp_token().balance(&pair.address), Uint128::new(1000));
+    assert_eq!(
+        generator.query_deposit(&pair.lp_token(), &astroport),
+        Uint128::new(999_999000),
+    );
+}
+
+#[test]
+fn test_imbalanced_withdraw_is_disabled() {
+    let owner = Addr::unchecked("owner");
+    let alice_address = Addr::unchecked("alice");
+    let mut router = mock_app(
+        owner.clone(),
+        vec![
+            Coin {
+                denom: "uusd".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+            Coin {
+                denom: "uluna".to_string(),
+                amount: Uint128::new(100_000_000_000u128),
+            },
+        ],
+    );
+
+    // Set Alice's balances
+    router
+        .send_tokens(
+            owner.clone(),
+            alice_address.clone(),
+            &[
+                Coin {
+                    denom: "uusd".to_string(),
+                    amount: Uint128::new(233_000_000u128),
+                },
+                Coin {
+                    denom: "uluna".to_string(),
+                    amount: Uint128::new(2_00_000_000u128),
+                },
+            ],
+        )
+        .unwrap();
+
+    // Init pair
+    let pair_instance = instantiate_pair(&mut router, &owner);
+
+    let res: PairInfo = router
+        .wrap()
+        .query_wasm_smart(pair_instance.to_string(), &QueryMsg::Pair {})
+        .unwrap();
+    let lp_token = res.liquidity_token;
+
+    assert_eq!(
+        res.asset_infos,
+        [
+            AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+            AssetInfo::NativeToken {
+                denom: "uluna".to_string(),
+            },
+        ],
+    );
+
+    // Provide liquidity
+    let (msg, coins) = provide_liquidity_msg(
+        Uint128::new(100_000_000),
+        Uint128::new(100_000_000),
+        None,
+        None,
+    );
+    router
+        .execute_contract(alice_address.clone(), pair_instance.clone(), &msg, &coins)
+        .unwrap();
+
+    // Provide liquidity for receiver
+    let (msg, coins) = provide_liquidity_msg(
+        Uint128::new(100),
+        Uint128::new(100),
+        Some("bob".to_string()),
+        None,
+    );
+    router
+        .execute_contract(alice_address.clone(), pair_instance.clone(), &msg, &coins)
+        .unwrap();
+
+    // Check that imbalanced withdraw is currently disabled
+    let msg_imbalance = Cw20ExecuteMsg::Send {
+        contract: pair_instance.to_string(),
+        amount: Uint128::from(50u8),
+        msg: to_binary(&Cw20HookMsg::WithdrawLiquidity {
+            assets: vec![Asset {
+                info: AssetInfo::NativeToken {
+                    denom: "uusd".to_string(),
+                },
+                amount: Uint128::from(100u8),
+            }],
+        })
+        .unwrap(),
+    };
+
+    let err = router
+        .execute_contract(alice_address.clone(), lp_token.clone(), &msg_imbalance, &[])
+        .unwrap_err();
+    assert_eq!(
+        err.root_cause().to_string(),
+        "Generic error: Imbalanced withdraw is currently disabled"
+    );
+}

--- a/contracts/pair_xyk_sale_tax/tests/integration.rs
+++ b/contracts/pair_xyk_sale_tax/tests/integration.rs
@@ -92,7 +92,7 @@ fn instantiate_pair(mut router: &mut App, owner: &Addr) -> Addr {
         pair_configs: vec![PairConfig {
             code_id: pair_contract_code_id,
             maker_fee_bps: 0,
-            pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
+            pair_type: PairType::Xyk {},
             total_fee_bps: 0,
             is_disabled: false,
             is_generator_disabled: false,
@@ -531,7 +531,7 @@ fn test_compatibility_of_tokens_with_different_precision() {
         pair_configs: vec![PairConfig {
             code_id: pair_code_id,
             maker_fee_bps: 0,
-            pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
+            pair_type: PairType::Xyk {},
             total_fee_bps: 0,
             is_disabled: false,
             is_generator_disabled: false,
@@ -561,7 +561,7 @@ fn test_compatibility_of_tokens_with_different_precision() {
             },
             AssetInfo::native("uusd"),
         ],
-        pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
+        pair_type: PairType::Xyk {},
         init_params: Some(to_binary(&SaleTaxInitParams::default()).unwrap()),
     };
 
@@ -904,7 +904,7 @@ fn asset_balances_tracking_works_correctly() {
         pair_configs: vec![PairConfig {
             code_id: pair_code_id,
             maker_fee_bps: 0,
-            pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
+            pair_type: PairType::Xyk {},
             total_fee_bps: 0,
             is_disabled: false,
             is_generator_disabled: false,
@@ -937,7 +937,7 @@ fn asset_balances_tracking_works_correctly() {
                 denom: "test2".to_string(),
             },
         ],
-        pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
+        pair_type: PairType::Xyk {},
         init_params: Some(
             to_binary(&SaleTaxInitParams {
                 tax_configs: TaxConfigsUnchecked::new(),
@@ -1145,7 +1145,7 @@ fn asset_balances_tracking_works_correctly() {
                 denom: "uusd".to_string(),
             },
         ],
-        pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
+        pair_type: PairType::Xyk {},
         init_params: Some(
             to_binary(&SaleTaxInitParams {
                 track_asset_balances: true,

--- a/contracts/pair_xyk_sale_tax/tests/integration.rs
+++ b/contracts/pair_xyk_sale_tax/tests/integration.rs
@@ -92,7 +92,7 @@ fn instantiate_pair(mut router: &mut App, owner: &Addr) -> Addr {
         pair_configs: vec![PairConfig {
             code_id: pair_contract_code_id,
             maker_fee_bps: 0,
-            pair_type: PairType::Xyk {},
+            pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
             total_fee_bps: 0,
             is_disabled: false,
             is_generator_disabled: false,
@@ -531,7 +531,7 @@ fn test_compatibility_of_tokens_with_different_precision() {
         pair_configs: vec![PairConfig {
             code_id: pair_code_id,
             maker_fee_bps: 0,
-            pair_type: PairType::Xyk {},
+            pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
             total_fee_bps: 0,
             is_disabled: false,
             is_generator_disabled: false,
@@ -561,7 +561,7 @@ fn test_compatibility_of_tokens_with_different_precision() {
             },
             AssetInfo::native("uusd"),
         ],
-        pair_type: PairType::Xyk {},
+        pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
         init_params: Some(to_binary(&SaleTaxInitParams::default()).unwrap()),
     };
 
@@ -904,7 +904,7 @@ fn asset_balances_tracking_works_correctly() {
         pair_configs: vec![PairConfig {
             code_id: pair_code_id,
             maker_fee_bps: 0,
-            pair_type: PairType::Xyk {},
+            pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
             total_fee_bps: 0,
             is_disabled: false,
             is_generator_disabled: false,
@@ -937,7 +937,7 @@ fn asset_balances_tracking_works_correctly() {
                 denom: "test2".to_string(),
             },
         ],
-        pair_type: PairType::Xyk {},
+        pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
         init_params: Some(
             to_binary(&SaleTaxInitParams {
                 tax_configs: TaxConfigsUnchecked::new(),
@@ -1145,7 +1145,7 @@ fn asset_balances_tracking_works_correctly() {
                 denom: "uusd".to_string(),
             },
         ],
-        pair_type: PairType::Xyk {},
+        pair_type: PairType::Custom(env!("CARGO_PKG_NAME").to_string()),
         init_params: Some(
             to_binary(&SaleTaxInitParams {
                 track_asset_balances: true,

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport"
-version = "3.8.0"
+version = "3.9.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "Common Astroport types, queriers and other utils"

--- a/packages/astroport/src/lib.rs
+++ b/packages/astroport/src/lib.rs
@@ -18,6 +18,7 @@ pub mod pair;
 pub mod pair_bonded;
 pub mod pair_concentrated;
 pub mod pair_concentrated_inj;
+pub mod pair_xyk_sale_tax;
 pub mod querier;
 pub mod restricted_vector;
 pub mod router;

--- a/packages/astroport/src/pair_xyk_sale_tax.rs
+++ b/packages/astroport/src/pair_xyk_sale_tax.rs
@@ -80,9 +80,10 @@ impl Default for TaxConfigsUnchecked {
 impl TaxConfigUnchecked {
     /// Checks that the params are valid and returns a `TaxConfigChecked`.
     pub fn check(self, api: &dyn Api) -> StdResult<TaxConfigChecked> {
-        // Tax rate cannot be more than 100%
-        if self.tax_rate > Decimal::one() {
-            return Err(StdError::generic_err("Tax rate cannot be more than 100%"));
+        // Tax rate cannot be more than 50% to avoid blocking swaps if set to 100% or errors if
+        // set to more than 100%.
+        if self.tax_rate > Decimal::percent(50) {
+            return Err(StdError::generic_err("Tax rate cannot be more than 50%"));
         }
 
         // Tax recipient must be a valid address

--- a/packages/astroport/src/pair_xyk_sale_tax.rs
+++ b/packages/astroport/src/pair_xyk_sale_tax.rs
@@ -41,6 +41,16 @@ impl From<TaxConfigsChecked> for TaxConfigsUnchecked {
         )
     }
 }
+impl From<Vec<(&str, TaxConfigUnchecked)>> for TaxConfigsUnchecked {
+    fn from(value: Vec<(&str, TaxConfigUnchecked)>) -> Self {
+        TaxConfigs(value.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+    }
+}
+impl From<Vec<(&str, TaxConfigChecked)>> for TaxConfigsChecked {
+    fn from(value: Vec<(&str, TaxConfigChecked)>) -> Self {
+        TaxConfigs(value.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+    }
+}
 
 /// Implement default for TaxConfig. Useful for testing
 impl Default for TaxConfigChecked {
@@ -58,11 +68,7 @@ impl Default for TaxConfigUnchecked {
 }
 impl Default for TaxConfigsChecked {
     fn default() -> Self {
-        TaxConfigs(
-            vec![("uusd".to_string(), TaxConfigChecked::default())]
-                .into_iter()
-                .collect(),
-        )
+        vec![("uusd", TaxConfigChecked::default())].into()
     }
 }
 impl Default for TaxConfigsUnchecked {
@@ -133,6 +139,8 @@ impl TaxConfigsChecked {
 pub struct SaleTaxConfigUpdates {
     /// The new tax configs to apply to the pair.
     pub tax_configs: Option<TaxConfigsUnchecked>,
+    /// The new address that is allowed to updated the tax configs.
+    pub tax_config_admin: Option<String>,
     /// Whether asset balances are tracked over blocks or not.
     /// They will not be tracked if the parameter is ignored.
     /// It can not be disabled later once enabled.
@@ -141,14 +149,25 @@ pub struct SaleTaxConfigUpdates {
 
 /// Extra data embedded in the default pair InstantiateMsg
 #[cw_serde]
-#[derive(Default)]
 pub struct SaleTaxInitParams {
     /// The configs of the trade taxes for the pair.
     pub tax_configs: TaxConfigs<String>,
+    /// The address that is allowed to updated the tax configs.
+    pub tax_config_admin: String,
     /// Whether asset balances are tracked over blocks or not.
     /// They will not be tracked if the parameter is ignored.
     /// It can not be disabled later once enabled.
     pub track_asset_balances: bool,
+}
+
+impl Default for SaleTaxInitParams {
+    fn default() -> Self {
+        Self {
+            tax_config_admin: "addr0000".to_string(),
+            tax_configs: TaxConfigs::default(),
+            track_asset_balances: false,
+        }
+    }
 }
 
 impl SaleTaxInitParams {

--- a/packages/astroport/src/pair_xyk_sale_tax.rs
+++ b/packages/astroport/src/pair_xyk_sale_tax.rs
@@ -1,0 +1,128 @@
+use crate::asset::{validate_native_denom, AssetInfo};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{from_binary, Addr, Api, Binary, Decimal, StdError, StdResult};
+
+#[cw_serde]
+pub struct TaxConfig<T> {
+    /// The tax rate to apply to token sales of `tax_denom`.
+    pub tax_rate: Decimal,
+    /// The address to send the tax to
+    pub tax_recipient: T,
+    /// The denom of the asset to tax sales of
+    pub tax_denom: String,
+}
+pub type TaxConfigChecked = TaxConfig<Addr>;
+pub type TaxConfigUnchecked = TaxConfig<String>;
+
+impl From<TaxConfigChecked> for TaxConfigUnchecked {
+    fn from(value: TaxConfigChecked) -> Self {
+        TaxConfigUnchecked {
+            tax_rate: value.tax_rate,
+            tax_recipient: value.tax_recipient.to_string(),
+            tax_denom: value.tax_denom,
+        }
+    }
+}
+
+/// Implement default for TaxConfig. Useful for testing
+impl Default for TaxConfigChecked {
+    fn default() -> Self {
+        TaxConfigChecked {
+            tax_rate: Decimal::percent(5),
+            tax_recipient: Addr::unchecked("addr0000"),
+            tax_denom: "uusd".to_string(),
+        }
+    }
+}
+impl Default for TaxConfigUnchecked {
+    fn default() -> Self {
+        TaxConfigChecked::default().into()
+    }
+}
+
+impl TaxConfigUnchecked {
+    /// Checks that the params are valid and returns a `TaxConfigChecked`.
+    pub fn check(
+        self,
+        api: &dyn Api,
+        pair_asset_infos: &[AssetInfo],
+    ) -> StdResult<TaxConfigChecked> {
+        // Tax rate cannot be more than 100%
+        if self.tax_rate > Decimal::one() {
+            return Err(StdError::generic_err("Tax rate cannot be more than 100%"));
+        }
+
+        // Tax recipient must be a valid address
+        let tax_recipient = api.addr_validate(&self.tax_recipient)?;
+
+        // Tax denom must be a valid denom
+        validate_native_denom(&self.tax_denom)?;
+
+        // Tax denom must be one of the pair assets
+        if !pair_asset_infos.contains(&AssetInfo::native(&self.tax_denom)) {
+            return Err(StdError::generic_err(
+                "Tax denom must be one of the pair assets",
+            ));
+        }
+
+        Ok(TaxConfigChecked {
+            tax_rate: self.tax_rate,
+            tax_recipient,
+            tax_denom: self.tax_denom,
+        })
+    }
+}
+
+/// Allows updating the config
+#[cw_serde]
+#[derive(Default)]
+pub struct SaleTaxConfigUpdates {
+    /// The tax rate to apply to token sales of `tax_denom`.
+    pub tax_rate: Option<Decimal>,
+    /// The address to send the tax to
+    pub tax_recipient: Option<String>,
+    /// The denom of the asset to tax sales of
+    pub tax_denom: Option<String>,
+    /// Whether asset balances are tracked over blocks or not.
+    /// They will not be tracked if the parameter is ignored.
+    /// It can not be disabled later once enabled.
+    pub track_asset_balances: Option<bool>,
+}
+
+impl TaxConfigChecked {
+    pub fn apply_updates(
+        &self,
+        api: &dyn Api,
+        pair_asset_infos: &[AssetInfo],
+        updates: SaleTaxConfigUpdates,
+    ) -> StdResult<Self> {
+        TaxConfigUnchecked {
+            tax_rate: updates.tax_rate.unwrap_or(self.tax_rate),
+            tax_recipient: updates
+                .tax_recipient
+                .unwrap_or_else(|| self.tax_recipient.clone().into()),
+            tax_denom: updates.tax_denom.unwrap_or_else(|| self.tax_denom.clone()),
+        }
+        .check(api, pair_asset_infos)
+    }
+}
+/// Extra data embedded in the default pair InstantiateMsg
+#[cw_serde]
+#[derive(Default)]
+pub struct SaleTaxInitParams {
+    pub tax_config: TaxConfigUnchecked,
+    /// Whether asset balances are tracked over blocks or not.
+    /// They will not be tracked if the parameter is ignored.
+    /// It can not be disabled later once enabled.
+    pub track_asset_balances: bool,
+}
+
+impl SaleTaxInitParams {
+    /// Deserializes the params from an `Option<Binary>`.
+    pub fn from_binary(data: Option<Binary>) -> StdResult<Self> {
+        data.as_ref()
+            .map(from_binary::<SaleTaxInitParams>)
+            .transpose()?
+            .ok_or_else(|| StdError::generic_err("Missing Init params"))
+    }
+}

--- a/packages/astroport/src/pair_xyk_sale_tax.rs
+++ b/packages/astroport/src/pair_xyk_sale_tax.rs
@@ -179,3 +179,12 @@ impl SaleTaxInitParams {
             .ok_or_else(|| StdError::generic_err("Missing Init params"))
     }
 }
+
+#[cw_serde]
+/// Message used when migrating the contract from the standard XYK pair.
+pub struct MigrateMsg {
+    /// The configs of the trade taxes for the pair.
+    pub tax_configs: TaxConfigs<String>,
+    /// The address that is allowed to updated the tax configs.
+    pub tax_config_admin: String,
+}


### PR DESCRIPTION
This contract is a copy of the standard XYK pair but adds a configurable tax on swaps.

After launching the APOLLO token, Apollo DAO will be submitting a proposal to migrate standard xyk pair to this contract. If the proposal passes, perhaps it makes sense to merge it into the main astroport-core repo.