### PR TITLE
fix(PCL): derive swap spread using oracle price

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,8 @@ dependencies = [
 [[package]]
 name = "astroport"
 version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b863a982595743e181f89540d7aaeda35c60b6b5cac9c36c9be30cf11a5ece"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -54,9 +56,7 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b863a982595743e181f89540d7aaeda35c60b6b5cac9c36c9be30cf11a5ece"
+version = "2.9.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -86,7 +86,7 @@ name = "astroport-factory"
 version = "1.5.1"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-pair",
  "astroport-token",
  "cosmwasm-schema",
@@ -105,7 +105,7 @@ name = "astroport-generator"
 version = "2.3.0"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-factory",
  "astroport-governance 1.2.0 (git+https://github.com/astroport-fi/astroport-governance?tag=v1.2.0)",
  "astroport-native-coin-registry",
@@ -139,7 +139,7 @@ dependencies = [
 name = "astroport-generator-proxy-template"
 version = "0.0.0"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -154,7 +154,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72806ace350e81c4e1cab7e275ef91f05bad830275d697d67ad1bd4acc6f016d"
 dependencies = [
- "astroport 2.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "astroport 2.9.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -166,7 +166,7 @@ name = "astroport-governance"
 version = "1.2.0"
 source = "git+https://github.com/astroport-fi/astroport-governance?tag=v1.2.0#6040b9d19f8d9118f1529e6f1e7d7edc2a3dcd2e"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -178,7 +178,7 @@ name = "astroport-governance"
 version = "1.2.0"
 source = "git+https://github.com/astroport-fi/astroport-governance?branch=main#193a33d72f9ee608d7fcff6c1f0425b84e22777a"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -190,7 +190,7 @@ name = "astroport-liquidity-manager"
 version = "1.0.3-astroport-v2"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-factory",
  "astroport-generator",
  "astroport-native-coin-registry",
@@ -215,7 +215,7 @@ name = "astroport-maker"
 version = "1.3.1"
 dependencies = [
  "astro-satellite-package",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-escrow-fee-distributor",
  "astroport-factory",
  "astroport-governance 1.2.0 (git+https://github.com/astroport-fi/astroport-governance?branch=main)",
@@ -236,7 +236,7 @@ dependencies = [
 name = "astroport-native-coin-registry"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -250,7 +250,7 @@ dependencies = [
 name = "astroport-native-coin-wrapper"
 version = "0.1.0"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -280,7 +280,7 @@ name = "astroport-oracle"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-pair",
@@ -300,7 +300,7 @@ dependencies = [
 name = "astroport-pair"
 version = "1.3.2"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-factory",
  "astroport-token",
  "cosmwasm-schema",
@@ -319,7 +319,7 @@ dependencies = [
 name = "astroport-pair-astro-xastro"
 version = "1.0.3"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-factory",
  "astroport-pair-bonded",
  "astroport-staking",
@@ -338,7 +338,7 @@ dependencies = [
 name = "astroport-pair-bonded"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
@@ -350,7 +350,7 @@ dependencies = [
 name = "astroport-pair-bonded-template"
 version = "1.0.0"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-pair-bonded",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -362,10 +362,10 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-concentrated"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-token",
@@ -387,7 +387,7 @@ name = "astroport-pair-stable"
 version = "2.1.3"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-token",
@@ -411,7 +411,7 @@ name = "astroport-router"
 version = "1.1.1"
 dependencies = [
  "anyhow",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-factory",
  "astroport-pair",
  "astroport-token",
@@ -429,7 +429,7 @@ dependencies = [
 name = "astroport-staking"
 version = "1.1.0"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -445,7 +445,7 @@ dependencies = [
 name = "astroport-token"
 version = "1.1.1"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2 0.15.1",
@@ -458,7 +458,7 @@ dependencies = [
 name = "astroport-vesting"
 version = "1.3.1"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -474,7 +474,7 @@ dependencies = [
 name = "astroport-whitelist"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw1-whitelist",
@@ -486,7 +486,7 @@ dependencies = [
 name = "astroport-xastro-token"
 version = "1.0.2"
 dependencies = [
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 0.15.1",
@@ -1180,7 +1180,7 @@ version = "0.0.0"
 source = "git+https://github.com/astroport-fi/astro-generator-proxy-contracts?branch=main#e573a8f8542b99015cac910f024a5f20fd793f3c"
 dependencies = [
  "ap-valkyrie",
- "astroport 2.9.0",
+ "astroport 2.9.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",

--- a/contracts/pair_concentrated/Cargo.toml
+++ b/contracts/pair_concentrated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-concentrated"
-version = "1.2.7"
+version = "1.2.8"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport concentrated liquidity pair"

--- a/contracts/pair_concentrated/src/contract.rs
+++ b/contracts/pair_concentrated/src/contract.rs
@@ -904,7 +904,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     match contract_version.contract.as_ref() {
         "astroport-pair-concentrated" => match contract_version.version.as_ref() {
-            "1.2.6" => {}
+            "1.2.7" => {}
             _ => return Err(ContractError::MigrationError {}),
         },
         _ => return Err(ContractError::MigrationError {}),

--- a/contracts/pair_concentrated/src/utils.rs
+++ b/contracts/pair_concentrated/src/utils.rs
@@ -268,7 +268,7 @@ pub fn calc_last_prices(xs: &[Decimal256], config: &Config, env: &Env) -> StdRes
 /// Calculate swap result.
 pub fn compute_swap(
     xs: &[Decimal256],
-    mut offer_amount: Decimal256,
+    offer_amount: Decimal256,
     ask_ind: usize,
     config: &Config,
     env: &Env,
@@ -283,22 +283,22 @@ pub fn compute_swap(
     let d = calc_d(&ixs, &amp_gamma)?;
 
     if offer_ind == 1 {
-        offer_amount *= config.pool_state.price_state.price_scale;
+        ixs[offer_ind] += offer_amount * config.pool_state.price_state.price_scale;
+    } else {
+        ixs[offer_ind] += offer_amount;
     }
-
-    ixs[offer_ind] += offer_amount;
 
     let new_y = calc_y(&ixs, d, &amp_gamma, ask_ind)?;
     let mut dy = ixs[ask_ind] - new_y;
     ixs[ask_ind] = new_y;
 
-    // Since price_scale moves slower than real price spread fee may become negative
-    let mut spread_fee = offer_amount.saturating_sub(dy);
-
-    if ask_ind == 1 {
+    // Derive spread using oracle price
+    let spread_fee = if ask_ind == 1 {
         dy /= config.pool_state.price_state.price_scale;
-        spread_fee /= config.pool_state.price_state.price_scale;
-    }
+        (offer_amount / config.pool_state.price_state.oracle_price).saturating_sub(dy)
+    } else {
+        offer_amount.saturating_sub(dy / config.pool_state.price_state.oracle_price)
+    };
 
     let fee_rate = config.pool_params.fee(&ixs);
     let total_fee = fee_rate * dy;
@@ -438,10 +438,11 @@ pub fn check_pair_registered(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::error::Error;
     use std::fmt::Display;
     use std::str::FromStr;
+
+    use super::*;
 
     pub fn f64_to_dec<T>(val: f64) -> T
     where

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport"
-version = "2.9.0"
+version = "2.9.1"
 authors = ["Astroport"]
 edition = "2021"
 description = "Common Astroport types, queriers and other utils"


### PR DESCRIPTION
PCL pools currently assert spread against price scale. If gap between internal oracle price and price scale is significant such swaps could possibly incur 20-25% spread according to internal calculations even tho it is fine from user’s perspective (they receive assets according to market price).

For example, current ASTRO - USDC.axl PCL pool state
 
<img width="280" alt="image" src="https://github.com/astroport-fi/astroport-core/assets/5527315/2431dc09-f98e-4413-a14e-cff12f6f8c83">

This PR is meant to mitigate this issue and assert spread against current market price a.k.a. internal oracle price (EMA). 