### PR TITLE
feat(router): add return_amount in response data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-router"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "astroport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "2.9.3"
+version = "2.9.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -86,7 +86,7 @@ name = "astroport-factory"
 version = "1.5.1"
 dependencies = [
  "anyhow",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-pair",
  "astroport-token",
  "cosmwasm-schema",
@@ -105,7 +105,7 @@ name = "astroport-generator"
 version = "2.3.0"
 dependencies = [
  "anyhow",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-factory",
  "astroport-governance 1.2.0 (git+https://github.com/astroport-fi/astroport-governance?tag=v1.2.0)",
  "astroport-native-coin-registry",
@@ -139,7 +139,7 @@ dependencies = [
 name = "astroport-generator-proxy-template"
 version = "0.0.0"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -166,7 +166,7 @@ name = "astroport-governance"
 version = "1.2.0"
 source = "git+https://github.com/astroport-fi/astroport-governance?tag=v1.2.0#6040b9d19f8d9118f1529e6f1e7d7edc2a3dcd2e"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -178,7 +178,7 @@ name = "astroport-governance"
 version = "1.2.0"
 source = "git+https://github.com/astroport-fi/astroport-governance?branch=main#193a33d72f9ee608d7fcff6c1f0425b84e22777a"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -190,7 +190,7 @@ name = "astroport-liquidity-manager"
 version = "1.0.3-astroport-v2"
 dependencies = [
  "anyhow",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-factory",
  "astroport-generator",
  "astroport-native-coin-registry",
@@ -215,7 +215,7 @@ name = "astroport-maker"
 version = "1.3.1"
 dependencies = [
  "astro-satellite-package",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-escrow-fee-distributor",
  "astroport-factory",
  "astroport-governance 1.2.0 (git+https://github.com/astroport-fi/astroport-governance?branch=main)",
@@ -236,7 +236,7 @@ dependencies = [
 name = "astroport-native-coin-registry"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -250,7 +250,7 @@ dependencies = [
 name = "astroport-native-coin-wrapper"
 version = "0.1.0"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -280,7 +280,7 @@ name = "astroport-oracle"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-pair",
@@ -300,7 +300,7 @@ dependencies = [
 name = "astroport-pair"
 version = "1.3.2"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-factory",
  "astroport-token",
  "cosmwasm-schema",
@@ -319,7 +319,7 @@ dependencies = [
 name = "astroport-pair-astro-xastro"
 version = "1.0.3"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-factory",
  "astroport-pair-bonded",
  "astroport-staking",
@@ -338,7 +338,7 @@ dependencies = [
 name = "astroport-pair-bonded"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
@@ -350,7 +350,7 @@ dependencies = [
 name = "astroport-pair-bonded-template"
 version = "1.0.0"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-pair-bonded",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -365,7 +365,7 @@ name = "astroport-pair-concentrated"
 version = "1.2.9"
 dependencies = [
  "anyhow",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-token",
@@ -387,7 +387,7 @@ name = "astroport-pair-stable"
 version = "2.1.3"
 dependencies = [
  "anyhow",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-token",
@@ -411,7 +411,7 @@ name = "astroport-router"
 version = "1.2.0"
 dependencies = [
  "anyhow",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-factory",
  "astroport-pair",
  "astroport-token",
@@ -429,7 +429,7 @@ dependencies = [
 name = "astroport-staking"
 version = "1.1.0"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -445,7 +445,7 @@ dependencies = [
 name = "astroport-token"
 version = "1.1.1"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2 0.15.1",
@@ -458,7 +458,7 @@ dependencies = [
 name = "astroport-vesting"
 version = "1.3.1"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -474,7 +474,7 @@ dependencies = [
 name = "astroport-whitelist"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw1-whitelist",
@@ -486,7 +486,7 @@ dependencies = [
 name = "astroport-xastro-token"
 version = "1.0.2"
 dependencies = [
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 0.15.1",
@@ -1180,7 +1180,7 @@ version = "0.0.0"
 source = "git+https://github.com/astroport-fi/astro-generator-proxy-contracts?branch=main#e573a8f8542b99015cac910f024a5f20fd793f3c"
 dependencies = [
  "ap-valkyrie",
- "astroport 2.9.3",
+ "astroport 2.9.4",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-router"
-version = "1.2.0"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "astroport 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-router"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "astroport 2.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -86,7 +86,7 @@ name = "astroport-factory"
 version = "1.5.1"
 dependencies = [
  "anyhow",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-pair",
  "astroport-token",
  "cosmwasm-schema",
@@ -105,7 +105,7 @@ name = "astroport-generator"
 version = "2.3.0"
 dependencies = [
  "anyhow",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-factory",
  "astroport-governance 1.2.0 (git+https://github.com/astroport-fi/astroport-governance?tag=v1.2.0)",
  "astroport-native-coin-registry",
@@ -139,7 +139,7 @@ dependencies = [
 name = "astroport-generator-proxy-template"
 version = "0.0.0"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -166,7 +166,7 @@ name = "astroport-governance"
 version = "1.2.0"
 source = "git+https://github.com/astroport-fi/astroport-governance?tag=v1.2.0#6040b9d19f8d9118f1529e6f1e7d7edc2a3dcd2e"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -178,7 +178,7 @@ name = "astroport-governance"
 version = "1.2.0"
 source = "git+https://github.com/astroport-fi/astroport-governance?branch=main#193a33d72f9ee608d7fcff6c1f0425b84e22777a"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
@@ -190,7 +190,7 @@ name = "astroport-liquidity-manager"
 version = "1.0.3-astroport-v2"
 dependencies = [
  "anyhow",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-factory",
  "astroport-generator",
  "astroport-native-coin-registry",
@@ -215,7 +215,7 @@ name = "astroport-maker"
 version = "1.3.1"
 dependencies = [
  "astro-satellite-package",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-escrow-fee-distributor",
  "astroport-factory",
  "astroport-governance 1.2.0 (git+https://github.com/astroport-fi/astroport-governance?branch=main)",
@@ -236,7 +236,7 @@ dependencies = [
 name = "astroport-native-coin-registry"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -250,7 +250,7 @@ dependencies = [
 name = "astroport-native-coin-wrapper"
 version = "0.1.0"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -280,7 +280,7 @@ name = "astroport-oracle"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-pair",
@@ -300,7 +300,7 @@ dependencies = [
 name = "astroport-pair"
 version = "1.3.2"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-factory",
  "astroport-token",
  "cosmwasm-schema",
@@ -319,7 +319,7 @@ dependencies = [
 name = "astroport-pair-astro-xastro"
 version = "1.0.3"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-factory",
  "astroport-pair-bonded",
  "astroport-staking",
@@ -338,7 +338,7 @@ dependencies = [
 name = "astroport-pair-bonded"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
@@ -350,7 +350,7 @@ dependencies = [
 name = "astroport-pair-bonded-template"
 version = "1.0.0"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-pair-bonded",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -365,7 +365,7 @@ name = "astroport-pair-concentrated"
 version = "1.2.9"
 dependencies = [
  "anyhow",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-token",
@@ -387,7 +387,7 @@ name = "astroport-pair-stable"
 version = "2.1.3"
 dependencies = [
  "anyhow",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-token",
@@ -408,10 +408,10 @@ dependencies = [
 
 [[package]]
 name = "astroport-router"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-factory",
  "astroport-pair",
  "astroport-token",
@@ -429,7 +429,7 @@ dependencies = [
 name = "astroport-staking"
 version = "1.1.0"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -445,7 +445,7 @@ dependencies = [
 name = "astroport-token"
 version = "1.1.1"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2 0.15.1",
@@ -458,7 +458,7 @@ dependencies = [
 name = "astroport-vesting"
 version = "1.3.1"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -474,7 +474,7 @@ dependencies = [
 name = "astroport-whitelist"
 version = "1.0.1"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw1-whitelist",
@@ -486,7 +486,7 @@ dependencies = [
 name = "astroport-xastro-token"
 version = "1.0.2"
 dependencies = [
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 0.15.1",
@@ -1180,7 +1180,7 @@ version = "0.0.0"
 source = "git+https://github.com/astroport-fi/astro-generator-proxy-contracts?branch=main#e573a8f8542b99015cac910f024a5f20fd793f3c"
 dependencies = [
  "ap-valkyrie",
- "astroport 2.9.2",
+ "astroport 2.9.3",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",

--- a/contracts/router/Cargo.toml
+++ b/contracts/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-router"
-version = "1.2.0"
+version = "1.1.2"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport router contract - provides multi-hop swap functionality for Astroport pools"

--- a/contracts/router/Cargo.toml
+++ b/contracts/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-router"
-version = "1.1.2"
+version = "1.2.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport router contract - provides multi-hop swap functionality for Astroport pools"

--- a/contracts/router/Cargo.toml
+++ b/contracts/router/Cargo.toml
@@ -28,7 +28,7 @@ cw20 = "0.15"
 cosmwasm-std = "1.1"
 cw-storage-plus = "0.15"
 integer-sqrt = "0.1"
-astroport = { path = "../../packages/astroport", version = "2.9.3" }
+astroport = { path = "../../packages/astroport", version = "2.9.4" }
 thiserror = { version = "1.0" }
 cosmwasm-schema = "1.1"
 

--- a/contracts/router/Cargo.toml
+++ b/contracts/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-router"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport router contract - provides multi-hop swap functionality for Astroport pools"
@@ -28,7 +28,7 @@ cw20 = "0.15"
 cosmwasm-std = "1.1"
 cw-storage-plus = "0.15"
 integer-sqrt = "0.1"
-astroport = { path = "../../packages/astroport", version = "2.8" }
+astroport = { path = "../../packages/astroport", version = "2.9.3" }
 thiserror = { version = "1.0" }
 cosmwasm-schema = "1.1"
 

--- a/contracts/router/README.md
+++ b/contracts/router/README.md
@@ -70,6 +70,8 @@ Swap UST => mABNB
 ### `execute_swap_operations`
 
 Performs multi-hop swap operations for native & Astroport tokens. Swaps execute one-by-one and the last swap will return the ask token. This function is public (can be called by anyone).
+Contract sets total 'return_amount' in response data after all routes are processed. See `SwapResponseData` type for more info.
+Note: Response data makes sense ONLY if the first token in multi-hop swap is native. Otherwise, cw20::send message resets response data.
 
 ### Example
 

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -12,7 +12,7 @@ use astroport::pair::{QueryMsg as PairQueryMsg, SimulationResponse};
 use astroport::querier::query_pair_info;
 use astroport::router::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-    SimulateSwapOperationsResponse, SwapOperation, MAX_SWAP_OPERATIONS,
+    SimulateSwapOperationsResponse, SwapOperation, SwapResponseData, MAX_SWAP_OPERATIONS,
 };
 
 use crate::error::ContractError;
@@ -234,7 +234,9 @@ fn assert_minimum_receive(
             amount: swap_amount,
         })
     } else {
-        Ok(Response::default())
+        Ok(Response::default().set_data(to_binary(&SwapResponseData {
+            return_amount: swap_amount,
+        })?))
     }
 }
 
@@ -277,7 +279,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     match contract_version.contract.as_ref() {
         "astroport-router" => match contract_version.version.as_ref() {
-            "1.0.0" | "1.1.0" => {}
+            "1.1.1" => {}
             _ => return Err(ContractError::MigrationError {}),
         },
         _ => return Err(ContractError::MigrationError {}),

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -1,8 +1,6 @@
-use std::collections::HashSet;
-
 use cosmwasm_std::{
     entry_point, from_binary, to_binary, Addr, Api, Binary, CosmosMsg, Decimal, Deps, DepsMut, Env,
-    MessageInfo, Response, StdError, StdResult, Uint128, WasmMsg,
+    MessageInfo, Response, StdResult, Uint128, WasmMsg,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::Cw20ReceiveMsg;
@@ -12,7 +10,7 @@ use astroport::pair::{QueryMsg as PairQueryMsg, SimulationResponse};
 use astroport::querier::query_pair_info;
 use astroport::router::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-    SimulateSwapOperationsResponse, SwapOperation, SwapResponseData, MAX_SWAP_OPERATIONS,
+    SimulateSwapOperationsResponse, SwapOperation, MAX_SWAP_OPERATIONS,
 };
 
 use crate::error::ContractError;
@@ -153,21 +151,11 @@ pub fn execute_swap_operations(
     to: Option<String>,
     max_spread: Option<Decimal>,
 ) -> Result<Response, ContractError> {
-    let operations_len = operations.len();
-    if operations_len == 0 {
-        return Err(ContractError::MustProvideOperations {});
-    }
-
-    if operations_len > MAX_SWAP_OPERATIONS {
-        return Err(ContractError::SwapLimitExceeded {});
-    }
-
-    // Assert the operations are properly set
     assert_operations(deps.api, &operations)?;
 
     let to = addr_opt_validate(deps.api, &to)?.unwrap_or(sender);
-
     let target_asset_info = operations.last().unwrap().get_target_asset_info();
+    let operations_len = operations.len();
 
     let mut messages = operations
         .into_iter()
@@ -234,9 +222,7 @@ fn assert_minimum_receive(
             amount: swap_amount,
         })
     } else {
-        Ok(Response::default().set_data(to_binary(&SwapResponseData {
-            return_amount: swap_amount,
-        })?))
+        Ok(Response::default())
     }
 }
 
@@ -306,21 +292,12 @@ fn simulate_swap_operations(
     offer_amount: Uint128,
     operations: Vec<SwapOperation>,
 ) -> Result<SimulateSwapOperationsResponse, ContractError> {
-    let config = CONFIG.load(deps.storage)?;
-    let astroport_factory = config.astroport_factory;
-
-    let operations_len = operations.len();
-    if operations_len == 0 {
-        return Err(ContractError::MustProvideOperations {});
-    }
-
-    if operations_len > MAX_SWAP_OPERATIONS {
-        return Err(ContractError::SwapLimitExceeded {});
-    }
-
     assert_operations(deps.api, &operations)?;
 
+    let config = CONFIG.load(deps.storage)?;
+    let astroport_factory = config.astroport_factory;
     let mut return_amount = offer_amount;
+
     for operation in operations.into_iter() {
         match operation {
             SwapOperation::AstroSwap {
@@ -361,7 +338,17 @@ fn simulate_swap_operations(
 ///
 /// * **operations** is a vector that contains objects of type [`SwapOperation`]. These are all the swap operations we check.
 fn assert_operations(api: &dyn Api, operations: &[SwapOperation]) -> Result<(), ContractError> {
-    let mut ask_asset_map: HashSet<String> = HashSet::new();
+    let operations_len = operations.len();
+    if operations_len == 0 {
+        return Err(ContractError::MustProvideOperations {});
+    }
+
+    if operations_len > MAX_SWAP_OPERATIONS {
+        return Err(ContractError::SwapLimitExceeded {});
+    }
+
+    let mut prev_ask_asset: Option<AssetInfo> = None;
+
     for operation in operations {
         let (offer_asset, ask_asset) = match operation {
             SwapOperation::AstroSwap {
@@ -372,15 +359,28 @@ fn assert_operations(api: &dyn Api, operations: &[SwapOperation]) -> Result<(), 
                 return Err(ContractError::NativeSwapNotSupported {})
             }
         };
+
         offer_asset.check(api)?;
         ask_asset.check(api)?;
 
-        ask_asset_map.remove(&offer_asset.to_string());
-        ask_asset_map.insert(ask_asset.to_string());
-    }
+        if offer_asset.equal(&ask_asset) {
+            return Err(ContractError::DoublingAssetsPath {
+                offer_asset: offer_asset.to_string(),
+                ask_asset: ask_asset.to_string(),
+            });
+        }
 
-    if ask_asset_map.len() != 1 {
-        return Err(StdError::generic_err("invalid operations; multiple output token").into());
+        if let Some(prev_ask_asset) = prev_ask_asset {
+            if prev_ask_asset != offer_asset {
+                return Err(ContractError::InvalidPathOperations {
+                    prev_ask_asset: prev_ask_asset.to_string(),
+                    next_offer_asset: offer_asset.to_string(),
+                    next_ask_asset: ask_asset.to_string(),
+                });
+            }
+        }
+
+        prev_ask_asset = Some(ask_asset);
     }
 
     Ok(())
@@ -419,7 +419,7 @@ mod testing {
                             denom: "uluna".to_string(),
                         },
                     },
-                ],
+                ]
             )
             .is_ok()
         );
@@ -454,7 +454,7 @@ mod testing {
                             contract_addr: Addr::unchecked("asset0002"),
                         },
                     },
-                ],
+                ]
             )
             .is_ok()
         );
@@ -489,7 +489,7 @@ mod testing {
                             contract_addr: Addr::unchecked("asset0002"),
                         },
                     },
-                ],
+                ]
             )
             .is_err()
         );

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    entry_point, from_binary, to_binary, Addr, Api, Binary, CosmosMsg, Decimal, Deps, DepsMut, Env,
-    MessageInfo, Response, StdResult, Uint128, WasmMsg,
+    entry_point, from_binary, to_binary, wasm_execute, Addr, Api, Binary, Decimal, Deps, DepsMut,
+    Env, MessageInfo, Reply, Response, StdError, StdResult, SubMsg, SubMsgResult, Uint128,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::Cw20ReceiveMsg;
@@ -10,17 +10,19 @@ use astroport::pair::{QueryMsg as PairQueryMsg, SimulationResponse};
 use astroport::querier::query_pair_info;
 use astroport::router::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-    SimulateSwapOperationsResponse, SwapOperation, MAX_SWAP_OPERATIONS,
+    SimulateSwapOperationsResponse, SwapOperation, SwapResponseData, MAX_SWAP_OPERATIONS,
 };
 
 use crate::error::ContractError;
 use crate::operations::execute_swap_operation;
-use crate::state::{Config, CONFIG};
+use crate::state::{Config, ReplyData, CONFIG, REPLY_DATA};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-router";
 /// Contract version that is used for migration.
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub const AFTER_SWAP_REPLY_ID: u64 = 1;
 
 /// Creates a new contract with the specified parameters in the [`InstantiateMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -91,18 +93,6 @@ pub fn execute(
             max_spread,
             single,
         } => execute_swap_operation(deps, env, info, operation, to, max_spread, single),
-        ExecuteMsg::AssertMinimumReceive {
-            asset_info,
-            prev_balance,
-            minimum_receive,
-            receiver,
-        } => assert_minimum_receive(
-            deps.as_ref(),
-            asset_info,
-            prev_balance,
-            minimum_receive,
-            deps.api.addr_validate(&receiver)?,
-        ),
     }
 }
 
@@ -157,72 +147,82 @@ pub fn execute_swap_operations(
     let target_asset_info = operations.last().unwrap().get_target_asset_info();
     let operations_len = operations.len();
 
-    let mut messages = operations
+    let messages = operations
         .into_iter()
         .enumerate()
         .map(|(operation_index, op)| {
-            Ok(CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: env.contract.address.to_string(),
-                funds: vec![],
-                msg: to_binary(&ExecuteMsg::ExecuteSwapOperation {
-                    operation: op,
-                    to: if operation_index == operations_len - 1 {
-                        Some(to.to_string())
-                    } else {
-                        None
+            if operation_index == operations_len - 1 {
+                wasm_execute(
+                    env.contract.address.to_string(),
+                    &ExecuteMsg::ExecuteSwapOperation {
+                        operation: op,
+                        to: Some(to.to_string()),
+                        max_spread,
+                        single: operations_len == 1,
                     },
-                    max_spread,
-                    single: operations_len == 1,
-                })?,
-            }))
+                    vec![],
+                )
+                .map(|inner_msg| SubMsg::reply_on_success(inner_msg, AFTER_SWAP_REPLY_ID))
+            } else {
+                wasm_execute(
+                    env.contract.address.to_string(),
+                    &ExecuteMsg::ExecuteSwapOperation {
+                        operation: op,
+                        to: None,
+                        max_spread,
+                        single: operations_len == 1,
+                    },
+                    vec![],
+                )
+                .map(SubMsg::new)
+            }
         })
-        .collect::<StdResult<Vec<CosmosMsg>>>()?;
+        .collect::<StdResult<Vec<_>>>()?;
 
-    // Execute minimum amount assertion
-    if let Some(minimum_receive) = minimum_receive {
-        let receiver_balance = target_asset_info.query_pool(&deps.querier, &to)?;
-        messages.push(CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: env.contract.address.to_string(),
-            funds: vec![],
-            msg: to_binary(&ExecuteMsg::AssertMinimumReceive {
-                asset_info: target_asset_info,
-                prev_balance: receiver_balance,
-                minimum_receive,
-                receiver: to.to_string(),
-            })?,
-        }));
-    }
+    let prev_balance = target_asset_info.query_pool(&deps.querier, &to)?;
+    REPLY_DATA.save(
+        deps.storage,
+        &ReplyData {
+            asset_info: target_asset_info,
+            prev_balance,
+            minimum_receive,
+            receiver: to.to_string(),
+        },
+    )?;
 
-    Ok(Response::new().add_messages(messages))
+    Ok(Response::new().add_submessages(messages))
 }
 
-/// Checks if an ask amount is equal to or above a minimum amount.
-///
-/// * **asset_info** asset to check the ask amount for.
-///
-/// * **prev_balance** previous balance that the swap receive had before getting `ask` assets.
-///
-/// * **minimum_receive** minimum amount of `ask` assets to receive.
-///
-/// * **receiver** address that received `ask` assets.
-fn assert_minimum_receive(
-    deps: Deps,
-    asset_info: AssetInfo,
-    prev_balance: Uint128,
-    minimum_receive: Uint128,
-    receiver: Addr,
-) -> Result<Response, ContractError> {
-    asset_info.check(deps.api)?;
-    let receiver_balance = asset_info.query_pool(&deps.querier, receiver)?;
-    let swap_amount = receiver_balance.checked_sub(prev_balance)?;
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+    match msg {
+        Reply {
+            id: AFTER_SWAP_REPLY_ID,
+            result: SubMsgResult::Ok(..),
+        } => {
+            let reply_data = REPLY_DATA.load(deps.storage)?;
+            let receiver_balance = reply_data
+                .asset_info
+                .query_pool(&deps.querier, reply_data.receiver)?;
+            let swap_amount = receiver_balance.checked_sub(reply_data.prev_balance)?;
 
-    if swap_amount < minimum_receive {
-        Err(ContractError::AssertionMinimumReceive {
-            receive: minimum_receive,
-            amount: swap_amount,
-        })
-    } else {
-        Ok(Response::default())
+            if let Some(minimum_receive) = reply_data.minimum_receive {
+                if swap_amount < minimum_receive {
+                    return Err(ContractError::AssertionMinimumReceive {
+                        receive: minimum_receive,
+                        amount: swap_amount,
+                    });
+                }
+            }
+
+            // Reply data makes sense ONLY if the first token in multi-hop swap is native.
+            let data = to_binary(&SwapResponseData {
+                return_amount: swap_amount,
+            })?;
+
+            Ok(Response::new().set_data(data))
+        }
+        _ => Err(StdError::generic_err("Failed to process reply").into()),
     }
 }
 
@@ -259,6 +259,7 @@ pub fn query_config(deps: Deps) -> Result<ConfigResponse, ContractError> {
 }
 
 /// Manages contract migration.
+#[cfg(not(tarpaulin_include))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     let contract_version = get_contract_version(deps.storage)?;

--- a/contracts/router/src/error.rs
+++ b/contracts/router/src/error.rs
@@ -7,6 +7,9 @@ pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
 
+    #[error("{0}")]
+    OverflowError(#[from] OverflowError),
+
     #[error("Unauthorized")]
     Unauthorized {},
 
@@ -40,10 +43,4 @@ pub enum ContractError {
 
     #[error("Contract can't be migrated!")]
     MigrationError {},
-}
-
-impl From<OverflowError> for ContractError {
-    fn from(o: OverflowError) -> Self {
-        StdError::from(o).into()
-    }
 }

--- a/contracts/router/src/error.rs
+++ b/contracts/router/src/error.rs
@@ -10,6 +10,22 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
+    #[error(
+        "The next offer asset must be the same as the previous ask asset; \
+    {prev_ask_asset} --> {next_offer_asset} --> {next_ask_asset}"
+    )]
+    InvalidPathOperations {
+        prev_ask_asset: String,
+        next_offer_asset: String,
+        next_ask_asset: String,
+    },
+
+    #[error("Doubling assets in one batch of path; {offer_asset} --> {ask_asset}")]
+    DoublingAssetsPath {
+        offer_asset: String,
+        ask_asset: String,
+    },
+
     #[error("Must specify swap operations!")]
     MustProvideOperations {},
 

--- a/contracts/router/src/state.rs
+++ b/contracts/router/src/state.rs
@@ -1,5 +1,6 @@
+use astroport::asset::AssetInfo;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::Item;
 
 /// Stores the contract config at the given key
@@ -10,4 +11,14 @@ pub const CONFIG: Item<Config> = Item::new("config");
 pub struct Config {
     /// The factory contract address
     pub astroport_factory: Addr,
+}
+
+pub const REPLY_DATA: Item<ReplyData> = Item::new("reply_data");
+
+#[cw_serde]
+pub struct ReplyData {
+    pub asset_info: AssetInfo,
+    pub prev_balance: Uint128,
+    pub minimum_receive: Option<Uint128>,
+    pub receiver: String,
 }

--- a/contracts/router/src/testing/tests.rs
+++ b/contracts/router/src/testing/tests.rs
@@ -1,10 +1,5 @@
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{from_binary, to_binary, Addr, Coin, ReplyOn, SubMsg, Uint128, WasmMsg};
-
-use crate::contract::{execute, instantiate, query};
-use crate::error::ContractError;
-use crate::testing::mock_querier::mock_dependencies;
-
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
 use astroport::asset::{native_asset_info, AssetInfo};
@@ -12,6 +7,10 @@ use astroport::router::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
     SimulateSwapOperationsResponse, SwapOperation, MAX_SWAP_OPERATIONS,
 };
+
+use crate::contract::{execute, instantiate, query, AFTER_SWAP_REPLY_ID};
+use crate::error::ContractError;
+use crate::testing::mock_querier::mock_dependencies;
 
 #[test]
 fn proper_initialization() {
@@ -164,29 +163,10 @@ fn execute_swap_operations() {
                     .unwrap(),
                 }
                 .into(),
-                id: 0,
+                id: AFTER_SWAP_REPLY_ID,
                 gas_limit: None,
-                reply_on: ReplyOn::Never,
-            },
-            SubMsg {
-                msg: WasmMsg::Execute {
-                    contract_addr: String::from(MOCK_CONTRACT_ADDR),
-                    funds: vec![],
-                    msg: to_binary(&ExecuteMsg::AssertMinimumReceive {
-                        asset_info: AssetInfo::Token {
-                            contract_addr: Addr::unchecked("asset0002"),
-                        },
-                        prev_balance: Uint128::zero(),
-                        minimum_receive: Uint128::from(1000000u128),
-                        receiver: String::from("addr0000"),
-                    })
-                    .unwrap(),
-                }
-                .into(),
-                id: 0,
-                gas_limit: None,
-                reply_on: ReplyOn::Never,
-            },
+                reply_on: ReplyOn::Success,
+            }
         ]
     );
 
@@ -301,9 +281,9 @@ fn execute_swap_operations() {
                     .unwrap(),
                 }
                 .into(),
-                id: 0,
+                id: AFTER_SWAP_REPLY_ID,
                 gas_limit: None,
-                reply_on: ReplyOn::Never,
+                reply_on: ReplyOn::Success,
             }
         ]
     );
@@ -437,90 +417,6 @@ fn query_buy_with_routes() {
         res,
         SimulateSwapOperationsResponse {
             amount: Uint128::from(1000000u128),
-        }
-    );
-}
-
-#[test]
-fn assert_minimum_receive_native_token() {
-    let mut deps = mock_dependencies(&[]);
-    deps.querier.with_balance(&[(
-        &String::from("addr0000"),
-        &[Coin {
-            denom: "uusd".to_string(),
-            amount: Uint128::from(1000000u128),
-        }],
-    )]);
-
-    let env = mock_env();
-    let info = mock_info("addr0000", &[]);
-    // Success
-    let msg = ExecuteMsg::AssertMinimumReceive {
-        asset_info: AssetInfo::NativeToken {
-            denom: "uusd".to_string(),
-        },
-        prev_balance: Uint128::zero(),
-        minimum_receive: Uint128::from(1000000u128),
-        receiver: String::from("addr0000"),
-    };
-    let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
-
-    // Assertion failed; native token
-    let msg = ExecuteMsg::AssertMinimumReceive {
-        asset_info: AssetInfo::NativeToken {
-            denom: "uusd".to_string(),
-        },
-        prev_balance: Uint128::zero(),
-        minimum_receive: Uint128::from(1000001u128),
-        receiver: String::from("addr0000"),
-    };
-    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
-    assert_eq!(
-        res,
-        ContractError::AssertionMinimumReceive {
-            receive: Uint128::new(1000001),
-            amount: Uint128::new(1000000),
-        }
-    );
-}
-
-#[test]
-fn assert_minimum_receive_token() {
-    let mut deps = mock_dependencies(&[]);
-
-    deps.querier.with_token_balances(&[(
-        &String::from("token0000"),
-        &[(&String::from("addr0000"), &Uint128::from(1000000u128))],
-    )]);
-
-    let env = mock_env();
-    let info = mock_info("addr0000", &[]);
-    // Success
-    let msg = ExecuteMsg::AssertMinimumReceive {
-        asset_info: AssetInfo::Token {
-            contract_addr: Addr::unchecked("token0000"),
-        },
-        prev_balance: Uint128::zero(),
-        minimum_receive: Uint128::from(1000000u128),
-        receiver: String::from("addr0000"),
-    };
-    let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
-
-    // Assertion failed; native token
-    let msg = ExecuteMsg::AssertMinimumReceive {
-        asset_info: AssetInfo::Token {
-            contract_addr: Addr::unchecked("token0000"),
-        },
-        prev_balance: Uint128::zero(),
-        minimum_receive: Uint128::from(1000001u128),
-        receiver: String::from("addr0000"),
-    };
-    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap_err();
-    assert_eq!(
-        res,
-        ContractError::AssertionMinimumReceive {
-            receive: Uint128::new(1000001),
-            amount: Uint128::new(1000000),
         }
     );
 }

--- a/contracts/router/src/testing/tests.rs
+++ b/contracts/router/src/testing/tests.rs
@@ -419,6 +419,16 @@ fn query_buy_with_routes() {
             amount: Uint128::from(1000000u128),
         }
     );
+
+    let msg = QueryMsg::SimulateSwapOperations {
+        offer_amount: Uint128::from(1000000u128),
+        operations: vec![SwapOperation::NativeSwap {
+            offer_denom: "ukrw".to_string(),
+            ask_denom: "test".to_string(),
+        }],
+    };
+    let err = query(deps.as_ref(), env.clone(), msg).unwrap_err();
+    assert_eq!(err, ContractError::NativeSwapNotSupported {});
 }
 
 #[test]

--- a/contracts/router/tests/factory_helper.rs
+++ b/contracts/router/tests/factory_helper.rs
@@ -1,11 +1,12 @@
 #![cfg(not(tarpaulin_include))]
 
 use anyhow::Result as AnyResult;
-use astroport::asset::{AssetInfo, PairInfo};
-use astroport::factory::{PairConfig, PairType, QueryMsg};
-use cosmwasm_std::{Addr, Binary};
+use cosmwasm_std::{coins, Addr, Binary};
 use cw20::MinterResponse;
 use cw_multi_test::{App, AppResponse, ContractWrapper, Executor};
+
+use astroport::asset::{AssetInfo, PairInfo};
+use astroport::factory::{PairConfig, PairType, QueryMsg};
 
 pub struct FactoryHelper {
     pub owner: Addr,
@@ -120,50 +121,21 @@ impl FactoryHelper {
         router: &mut App,
         sender: &Addr,
         pair_type: PairType,
-        tokens: [&Addr; 2],
+        asset_infos: [AssetInfo; 2],
         init_params: Option<Binary>,
-    ) -> AnyResult<AppResponse> {
-        let asset_infos = vec![
-            AssetInfo::Token {
-                contract_addr: tokens[0].clone(),
-            },
-            AssetInfo::Token {
-                contract_addr: tokens[1].clone(),
-            },
-        ];
-
+    ) -> AnyResult<Addr> {
         let msg = astroport::factory::ExecuteMsg::CreatePair {
             pair_type,
-            asset_infos,
+            asset_infos: asset_infos.to_vec(),
             init_params,
         };
 
-        router.execute_contract(sender.clone(), self.factory.clone(), &msg, &[])
-    }
-
-    pub fn create_pair_with_addr(
-        &mut self,
-        router: &mut App,
-        sender: &Addr,
-        pair_type: PairType,
-        tokens: [&Addr; 2],
-        init_params: Option<Binary>,
-    ) -> AnyResult<Addr> {
-        self.create_pair(router, sender, pair_type, tokens, init_params)?;
-
-        let asset_infos = vec![
-            AssetInfo::Token {
-                contract_addr: tokens[0].clone(),
-            },
-            AssetInfo::Token {
-                contract_addr: tokens[1].clone(),
-            },
-        ];
+        router.execute_contract(sender.clone(), self.factory.clone(), &msg, &[])?;
 
         let res: PairInfo = router.wrap().query_wasm_smart(
             self.factory.clone(),
             &QueryMsg::Pair {
-                asset_infos: asset_infos.clone(),
+                asset_infos: asset_infos.to_vec(),
             },
         )?;
 
@@ -217,4 +189,23 @@ pub fn mint(
         },
         &[],
     )
+}
+
+pub fn mint_native(
+    app: &mut App,
+    denom: &str,
+    amount: u128,
+    receiver: &Addr,
+) -> AnyResult<AppResponse> {
+    // .init_balance() erases previous balance thus we use such hack and create intermediate "denom admin"
+    let denom_admin = Addr::unchecked(format!("{denom}_admin"));
+    let coins_vec = coins(amount, denom);
+    app.init_modules(|router, _, storage| {
+        router
+            .bank
+            .init_balance(storage, &denom_admin, coins_vec.clone())
+    })
+    .unwrap();
+
+    app.send_tokens(denom_admin, receiver.clone(), &coins_vec)
 }

--- a/contracts/router/tests/factory_helper.rs
+++ b/contracts/router/tests/factory_helper.rs
@@ -1,3 +1,5 @@
+#![cfg(not(tarpaulin_include))]
+
 use anyhow::Result as AnyResult;
 use astroport::asset::{AssetInfo, PairInfo};
 use astroport::factory::{PairConfig, PairType, QueryMsg};

--- a/contracts/router/tests/router_integration.rs
+++ b/contracts/router/tests/router_integration.rs
@@ -1,10 +1,12 @@
+#![cfg(not(tarpaulin_include))]
+
 mod factory_helper;
 
 use crate::factory_helper::{instantiate_token, mint, FactoryHelper};
 use astroport::asset::token_asset_info;
 use astroport::factory::PairType;
 use astroport::router::{ExecuteMsg, InstantiateMsg, SwapOperation};
-use cosmwasm_std::{to_binary, Addr, Empty};
+use cosmwasm_std::{to_binary, Addr, Empty, StdError};
 use cw20::Cw20ExecuteMsg;
 use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 
@@ -108,4 +110,573 @@ fn router_does_not_enforce_spread_assertion() {
         astroport_pair::error::ContractError::MaxSpreadAssertion {},
         err.downcast().unwrap()
     )
+}
+
+#[test]
+fn test_swap_route() {
+    use crate::factory_helper::{instantiate_token, mint, FactoryHelper};
+    use astroport::asset::AssetInfo;
+    use astroport::factory::PairType;
+    use astroport::router::{
+        ExecuteMsg, InstantiateMsg, QueryMsg, SimulateSwapOperationsResponse, SwapOperation,
+    };
+    use cosmwasm_std::{to_binary, Addr, Uint128};
+    use cw20::{BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg};
+    let mut app = App::default();
+    let owner = Addr::unchecked("owner");
+    let mut helper = FactoryHelper::init(&mut app, &owner);
+    let astro = instantiate_token(&mut app, helper.cw20_token_code_id, &owner, "astro", None);
+    let inj = instantiate_token(&mut app, helper.cw20_token_code_id, &owner, "inj", None);
+    let atom = instantiate_token(&mut app, helper.cw20_token_code_id, &owner, "atom", None);
+    let osmo = instantiate_token(&mut app, helper.cw20_token_code_id, &owner, "osmo", None);
+
+    for (a, b, typ, liq) in [
+        (&astro, &inj, PairType::Xyk {}, 100_000_000000),
+        (&inj, &osmo, PairType::Xyk {}, 100_000_000000),
+        (&atom, &osmo, PairType::Xyk {}, 100_000_000000),
+    ] {
+        let pair = helper
+            .create_pair_with_addr(&mut app, &owner, typ, [a, b], None)
+            .unwrap();
+        mint(&mut app, &owner, a, liq, &pair).unwrap();
+        mint(&mut app, &owner, b, liq, &pair).unwrap();
+    }
+    let router_code = app.store_code(router_contract());
+    let router = app
+        .instantiate_contract(
+            router_code,
+            owner.clone(),
+            &InstantiateMsg {
+                astroport_factory: helper.factory.to_string(),
+            },
+            &[],
+            "router",
+            None,
+        )
+        .unwrap();
+
+    let swap_amount = Uint128::new(10_000_000);
+
+    // Try to swap with a bad batch of path
+    // route: astro -> inj, atom -> osmo
+    let swap_operations = vec![
+        SwapOperation::AstroSwap {
+            offer_asset_info: AssetInfo::Token {
+                contract_addr: astro.clone(),
+            },
+            ask_asset_info: AssetInfo::Token {
+                contract_addr: inj.clone(),
+            },
+        },
+        SwapOperation::AstroSwap {
+            offer_asset_info: AssetInfo::Token {
+                contract_addr: atom.clone(),
+            },
+            ask_asset_info: AssetInfo::Token {
+                contract_addr: osmo.clone(),
+            },
+        },
+    ];
+
+    let err = app
+        .wrap()
+        .query_wasm_smart::<SimulateSwapOperationsResponse>(
+            router.clone(),
+            &QueryMsg::SimulateSwapOperations {
+                offer_amount: swap_amount,
+                operations: swap_operations.clone(),
+            },
+        )
+        .unwrap_err();
+    assert_eq!(
+        err,
+        StdError::generic_err(
+            "Querier contract error: The next offer asset must be \
+    the same as the previous ask asset; contract3 --> contract4 --> contract5"
+        )
+    );
+
+    // swap astro for osmo
+    // route: astro -> inj, inj -> osmo, osmo -> atom, atom -> osmo
+    let swap_operations = vec![
+        SwapOperation::AstroSwap {
+            offer_asset_info: AssetInfo::Token {
+                contract_addr: astro.clone(),
+            },
+            ask_asset_info: AssetInfo::Token {
+                contract_addr: inj.clone(),
+            },
+        },
+        SwapOperation::AstroSwap {
+            offer_asset_info: AssetInfo::Token {
+                contract_addr: inj.clone(),
+            },
+            ask_asset_info: AssetInfo::Token {
+                contract_addr: osmo.clone(),
+            },
+        },
+        SwapOperation::AstroSwap {
+            offer_asset_info: AssetInfo::Token {
+                contract_addr: osmo.clone(),
+            },
+            ask_asset_info: AssetInfo::Token {
+                contract_addr: atom.clone(),
+            },
+        },
+        SwapOperation::AstroSwap {
+            offer_asset_info: AssetInfo::Token {
+                contract_addr: atom.clone(),
+            },
+            ask_asset_info: AssetInfo::Token {
+                contract_addr: osmo.clone(),
+            },
+        },
+    ];
+
+    // the simulation succeeds
+    let simulate_res: SimulateSwapOperationsResponse = app
+        .wrap()
+        .query_wasm_smart(
+            router.clone(),
+            &QueryMsg::SimulateSwapOperations {
+                offer_amount: swap_amount,
+                operations: swap_operations.clone(),
+            },
+        )
+        .unwrap();
+
+    assert_eq!(simulate_res.amount, Uint128::new(9996000));
+    println!(
+        "0. User simulate swap, expected return amount: {:?}",
+        simulate_res.amount
+    );
+
+    let user = Addr::unchecked("user");
+    mint(&mut app, &owner, &astro, swap_amount.u128(), &user).unwrap();
+
+    // query balance
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: user.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, swap_amount);
+
+    // swap
+    app.execute_contract(
+        user.clone(),
+        astro.clone(),
+        &Cw20ExecuteMsg::Send {
+            contract: router.to_string(),
+            amount: swap_amount,
+            msg: to_binary(&ExecuteMsg::ExecuteSwapOperations {
+                operations: swap_operations.clone(),
+                minimum_receive: None,
+                to: None,
+                max_spread: None,
+            })
+            .unwrap(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let attacker = Addr::unchecked("attacker");
+    let donated_atom: u128 = 1;
+
+    mint(&mut app, &owner, &atom, donated_atom, &attacker).unwrap();
+
+    // attacker donates little amount to router contract
+    app.execute_contract(
+        attacker.clone(),
+        atom.clone(),
+        &Cw20ExecuteMsg::Transfer {
+            recipient: router.to_string(),
+            amount: Uint128::new(donated_atom),
+        },
+        &[],
+    )
+    .unwrap();
+
+    // query balance
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            atom.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::new(1));
+
+    // query balance
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: user.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    // query balance
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            osmo.clone(),
+            &Cw20QueryMsg::Balance {
+                address: user.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::new(9997999));
+
+    // query balance
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            osmo.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    // mint more astro to user
+    mint(&mut app, &owner, &astro, swap_amount.u128(), &user).unwrap();
+
+    // victim tx gets executed. Assume user provide `minimum_receive` as `None`"
+    app.execute_contract(
+        user.clone(),
+        astro.clone(),
+        &Cw20ExecuteMsg::Send {
+            contract: router.to_string(),
+            amount: swap_amount,
+            msg: to_binary(&ExecuteMsg::ExecuteSwapOperations {
+                operations: swap_operations.clone(),
+                minimum_receive: None,
+                to: None,
+                max_spread: None,
+            })
+            .unwrap(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    // Query victim balance
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: user.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            atom.clone(),
+            &Cw20QueryMsg::Balance {
+                address: user.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            osmo.clone(),
+            &Cw20QueryMsg::Balance {
+                address: user.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::new(19992001));
+
+    // Query router contract balance
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            atom.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            osmo.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    println!("OSMO router balance: {:?}", balance_res.balance);
+
+    // attacker try back-runs the tx and withdraw nothing
+    let err = app
+        .execute_contract(
+            attacker.clone(),
+            router.clone(),
+            &ExecuteMsg::ExecuteSwapOperations {
+                operations: vec![SwapOperation::AstroSwap {
+                    offer_asset_info: AssetInfo::Token {
+                        contract_addr: osmo.clone(),
+                    },
+                    ask_asset_info: AssetInfo::Token {
+                        contract_addr: atom.clone(),
+                    },
+                }],
+                minimum_receive: Some(Uint128::new(9_997_000)),
+                to: None,
+                max_spread: None,
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert_eq!(err.root_cause().to_string(), "Invalid zero amount");
+
+    // Query attacker balance and calculate profit
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: attacker.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            atom.clone(),
+            &Cw20QueryMsg::Balance {
+                address: attacker.to_string(),
+            },
+        )
+        .unwrap();
+
+    println!("ATOM attacker balance: {:?}", balance_res.balance);
+    println!("Donated ATOM: {:?}", donated_atom);
+
+    let profit = balance_res
+        .balance
+        .saturating_sub(Uint128::new(donated_atom));
+    println!("Attacker's profit: {:?}", profit);
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            osmo.clone(),
+            &Cw20QueryMsg::Balance {
+                address: attacker.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    // double check router contract have no funds left
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            atom.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            osmo.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    /* -------------------------------------------------------------------------------------------
+    2. lets try attack with minimum_receive as Some(_).
+    -------------------------------------------------------------------------------------------*/
+    println!("\n2. Assume user provide `minimum_receive` as `Some(_)`");
+
+    mint(&mut app, &owner, &astro, swap_amount.u128(), &user).unwrap();
+
+    // query balance
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: user.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, swap_amount);
+
+    // attacker2 front-run tx
+    let attacker2 = Addr::unchecked("attacker2");
+
+    // assume the market is bad and user wants to get as much as they can
+    let donated_atom = Uint128::new(9_000_000);
+
+    // attacker2 donate funds
+    mint(&mut app, &owner, &atom, donated_atom.u128(), &attacker2).unwrap();
+
+    app.execute_contract(
+        attacker2.clone(),
+        atom.clone(),
+        &Cw20ExecuteMsg::Transfer {
+            recipient: router.to_string(),
+            amount: donated_atom,
+        },
+        &[],
+    )
+    .unwrap();
+
+    // victim tx gets executed
+    app.execute_contract(
+        user.clone(),
+        astro.clone(),
+        &Cw20ExecuteMsg::Send {
+            contract: router.to_string(),
+            amount: swap_amount,
+            msg: to_binary(&ExecuteMsg::ExecuteSwapOperations {
+                operations: swap_operations.clone(),
+                minimum_receive: Some(donated_atom),
+                to: None,
+                max_spread: None,
+            })
+            .unwrap(),
+        },
+        &[],
+    )
+    .unwrap();
+
+    // query router contract
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    println!("ASTRO router balance: {:?}", balance_res.balance);
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            atom.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    println!("ATOM router balance: {:?}", balance_res.balance);
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            osmo.clone(),
+            &Cw20QueryMsg::Balance {
+                address: router.to_string(),
+            },
+        )
+        .unwrap();
+    println!("OSMO router balance: {:?}", balance_res.balance);
+
+    // attacker back-runs tx to withdraw funds
+    let err = app
+        .execute_contract(
+            attacker2.clone(),
+            router.clone(),
+            &ExecuteMsg::ExecuteSwapOperations {
+                operations: vec![SwapOperation::AstroSwap {
+                    offer_asset_info: AssetInfo::Token {
+                        contract_addr: osmo.clone(),
+                    },
+                    ask_asset_info: AssetInfo::Token {
+                        contract_addr: atom.clone(),
+                    },
+                }],
+                minimum_receive: None,
+                to: None,
+                max_spread: None,
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert_eq!(err.root_cause().to_string(), "Invalid zero amount");
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            astro.clone(),
+            &Cw20QueryMsg::Balance {
+                address: attacker2.to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(balance_res.balance, Uint128::zero());
+
+    let balance_res: BalanceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            atom.clone(),
+            &Cw20QueryMsg::Balance {
+                address: attacker2.to_string(),
+            },
+        )
+        .unwrap();
+
+    println!("ATOM attacker2 balance: {:?}", balance_res.balance);
+    println!("Donated ATOM: {:?}", donated_atom);
+
+    let profit = balance_res.balance.saturating_sub(donated_atom);
+    println!("Attacker2's profit: {:?}", profit);
 }

--- a/contracts/router/tests/router_integration.rs
+++ b/contracts/router/tests/router_integration.rs
@@ -1,21 +1,26 @@
 #![cfg(not(tarpaulin_include))]
 
-mod factory_helper;
-
-use crate::factory_helper::{instantiate_token, mint, FactoryHelper};
-use astroport::asset::token_asset_info;
-use astroport::factory::PairType;
-use astroport::router::{ExecuteMsg, InstantiateMsg, SwapOperation};
-use cosmwasm_std::{to_binary, Addr, Empty, StdError};
+use cosmwasm_std::{coins, from_binary, to_binary, Addr, Empty, StdError};
 use cw20::Cw20ExecuteMsg;
 use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 
+use astroport::asset::{native_asset_info, token_asset_info};
+use astroport::factory::PairType;
+use astroport::router::{ExecuteMsg, InstantiateMsg, SwapOperation, SwapResponseData};
+
+use crate::factory_helper::{instantiate_token, mint, mint_native, FactoryHelper};
+
+mod factory_helper;
+
 fn router_contract() -> Box<dyn Contract<Empty>> {
-    Box::new(ContractWrapper::new_with_empty(
-        astroport_router::contract::execute,
-        astroport_router::contract::instantiate,
-        astroport_router::contract::query,
-    ))
+    Box::new(
+        ContractWrapper::new_with_empty(
+            astroport_router::contract::execute,
+            astroport_router::contract::instantiate,
+            astroport_router::contract::query,
+        )
+        .with_reply_empty(astroport_router::contract::reply),
+    )
 }
 
 #[test]
@@ -34,7 +39,13 @@ fn router_does_not_enforce_spread_assertion() {
         (&token_y, &token_z, PairType::Stable {}, 1_000_000_000000),
     ] {
         let pair = helper
-            .create_pair_with_addr(&mut app, &owner, typ, [a, b], None)
+            .create_pair(
+                &mut app,
+                &owner,
+                typ,
+                [token_asset_info(a.clone()), token_asset_info(b.clone())],
+                None,
+            )
             .unwrap();
         mint(&mut app, &owner, a, liq, &pair).unwrap();
         mint(&mut app, &owner, b, liq, &pair).unwrap();
@@ -56,32 +67,39 @@ fn router_does_not_enforce_spread_assertion() {
 
     // Triggering swap with a huge spread fees
     mint(&mut app, &owner, &token_x, 50_000_000000, &owner).unwrap();
-    app.execute_contract(
-        owner.clone(),
-        token_x.clone(),
-        &Cw20ExecuteMsg::Send {
-            contract: router.to_string(),
-            amount: 50_000_000000u128.into(),
-            msg: to_binary(&ExecuteMsg::ExecuteSwapOperations {
-                operations: vec![
-                    SwapOperation::AstroSwap {
-                        offer_asset_info: token_asset_info(token_x.clone()),
-                        ask_asset_info: token_asset_info(token_y.clone()),
-                    },
-                    SwapOperation::AstroSwap {
-                        offer_asset_info: token_asset_info(token_y.clone()),
-                        ask_asset_info: token_asset_info(token_z.clone()),
-                    },
-                ],
-                minimum_receive: None,
-                to: None,
-                max_spread: None,
-            })
-            .unwrap(),
-        },
-        &[],
-    )
-    .unwrap();
+    let resp = app
+        .execute_contract(
+            owner.clone(),
+            token_x.clone(),
+            &Cw20ExecuteMsg::Send {
+                contract: router.to_string(),
+                amount: 50_000_000000u128.into(),
+                msg: to_binary(&ExecuteMsg::ExecuteSwapOperations {
+                    operations: vec![
+                        SwapOperation::AstroSwap {
+                            offer_asset_info: token_asset_info(token_x.clone()),
+                            ask_asset_info: token_asset_info(token_y.clone()),
+                        },
+                        SwapOperation::AstroSwap {
+                            offer_asset_info: token_asset_info(token_y.clone()),
+                            ask_asset_info: token_asset_info(token_z.clone()),
+                        },
+                    ],
+                    minimum_receive: None,
+                    to: None,
+                    max_spread: None,
+                })
+                .unwrap(),
+            },
+            &[],
+        )
+        .unwrap();
+
+    // We can't set data in response if the first message dispatched from cw20 contract
+    assert!(
+        resp.data.is_none(),
+        "Unexpected data set after cw20 send hook"
+    );
 
     // However, single hop will still enforce spread assertion
     mint(&mut app, &owner, &token_x, 50_000_000000, &owner).unwrap();
@@ -113,6 +131,80 @@ fn router_does_not_enforce_spread_assertion() {
 }
 
 #[test]
+fn route_through_pairs_with_natives() {
+    let mut app = App::default();
+
+    let owner = Addr::unchecked("owner");
+    let mut helper = FactoryHelper::init(&mut app, &owner);
+
+    let denom_x = "denom_x";
+    let denom_y = "denom_y";
+    let denom_z = "denom_z";
+
+    for (a, b, typ, liq) in [
+        (&denom_x, &denom_y, PairType::Xyk {}, 100_000_000000),
+        (&denom_y, &denom_z, PairType::Stable {}, 1_000_000_000000),
+    ] {
+        let pair = helper
+            .create_pair(
+                &mut app,
+                &owner,
+                typ,
+                [
+                    native_asset_info(a.to_string()),
+                    native_asset_info(b.to_string()),
+                ],
+                None,
+            )
+            .unwrap();
+        mint_native(&mut app, a, liq, &pair).unwrap();
+        mint_native(&mut app, b, liq, &pair).unwrap();
+    }
+
+    let router_code = app.store_code(router_contract());
+    let router = app
+        .instantiate_contract(
+            router_code,
+            owner.clone(),
+            &InstantiateMsg {
+                astroport_factory: helper.factory.to_string(),
+            },
+            &[],
+            "router",
+            None,
+        )
+        .unwrap();
+
+    mint_native(&mut app, &denom_x, 50_000_000000, &owner).unwrap();
+    let resp = app
+        .execute_contract(
+            owner.clone(),
+            router,
+            &ExecuteMsg::ExecuteSwapOperations {
+                operations: vec![
+                    SwapOperation::AstroSwap {
+                        offer_asset_info: native_asset_info(denom_x.to_string()),
+                        ask_asset_info: native_asset_info(denom_y.to_string()),
+                    },
+                    SwapOperation::AstroSwap {
+                        offer_asset_info: native_asset_info(denom_y.to_string()),
+                        ask_asset_info: native_asset_info(denom_z.to_string()),
+                    },
+                ],
+                minimum_receive: None,
+                to: None,
+                max_spread: None,
+            },
+            &coins(50_000_000000, denom_x),
+        )
+        .unwrap();
+
+    let resp_data: SwapResponseData = from_binary(&resp.data.unwrap()).unwrap();
+
+    assert_eq!(resp_data.return_amount.u128(), 32_258_064515);
+}
+
+#[test]
 fn test_swap_route() {
     use crate::factory_helper::{instantiate_token, mint, FactoryHelper};
     use astroport::asset::AssetInfo;
@@ -136,7 +228,13 @@ fn test_swap_route() {
         (&atom, &osmo, PairType::Xyk {}, 100_000_000000),
     ] {
         let pair = helper
-            .create_pair_with_addr(&mut app, &owner, typ, [a, b], None)
+            .create_pair(
+                &mut app,
+                &owner,
+                typ,
+                [token_asset_info(a.clone()), token_asset_info(b.clone())],
+                None,
+            )
             .unwrap();
         mint(&mut app, &owner, a, liq, &pair).unwrap();
         mint(&mut app, &owner, b, liq, &pair).unwrap();

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport"
-version = "2.9.2"
+version = "2.9.3"
 authors = ["Astroport"]
 edition = "2021"
 description = "Common Astroport types, queriers and other utils"

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport"
-version = "2.9.3"
+version = "2.9.4"
 authors = ["Astroport"]
 edition = "2021"
 description = "Common Astroport types, queriers and other utils"

--- a/packages/astroport/src/router.rs
+++ b/packages/astroport/src/router.rs
@@ -65,14 +65,6 @@ pub enum ExecuteMsg {
         max_spread: Option<Decimal>,
         single: bool,
     },
-    /// Internal use
-    /// AssertMinimumReceive checks that a receiver will get a minimum amount of tokens from a swap
-    AssertMinimumReceive {
-        asset_info: AssetInfo,
-        prev_balance: Uint128,
-        minimum_receive: Uint128,
-        receiver: String,
-    },
 }
 
 #[cw_serde]

--- a/packages/astroport/src/router.rs
+++ b/packages/astroport/src/router.rs
@@ -76,6 +76,11 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
+pub struct SwapResponseData {
+    pub return_amount: Uint128,
+}
+
+#[cw_serde]
 pub enum Cw20HookMsg {
     ExecuteSwapOperations {
         /// A vector of swap operations


### PR DESCRIPTION
1. Cherry-pick router contract from Astroport [v3.2.2](https://github.com/astroport-fi/astroport-core/tree/v3.3.2)
2. Set response data with return amount. It is processed in reply after all swaps via router finished.
3. Increase router code coverage.