### PR TITLE
PCL: Allow migration from v1.2.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-concentrated"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "anyhow",
  "astroport",

--- a/contracts/pair_concentrated/Cargo.toml
+++ b/contracts/pair_concentrated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-concentrated"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport concentrated liquidity pair"

--- a/contracts/pair_concentrated/src/contract.rs
+++ b/contracts/pair_concentrated/src/contract.rs
@@ -958,7 +958,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     match contract_version.contract.as_ref() {
         "astroport-pair-concentrated" => match contract_version.version.as_ref() {
-            "1.1.0" => migrate_config(deps.storage)?,
+            "1.1.0" | "1.2.13" => migrate_config(deps.storage)?,
             "1.2.4" => {
                 BufferManager::init(deps.storage, OBSERVATIONS, OBSERVATIONS_SIZE)?;
             }


### PR DESCRIPTION
This PR allows the currently deployed PCL version v1.2.13 to be upgraded to the latest PCL version with fee sharing