### PR TITLE
Impl From Asset/AssetInfo for cw-asset::Asset/AssetInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "astroport-circular-buffer",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-asset",
  "cw-storage-plus 0.15.1",
  "cw-utils 1.0.1",
  "cw20 0.15.1",
@@ -939,6 +940,29 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "cw-address-like"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451a4691083a88a3c0630a8a88799e9d4cd6679b7ce8ff22b8da2873ff31d380"
+dependencies = [
+ "cosmwasm-std",
+]
+
+[[package]]
+name = "cw-asset"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e2cf17accdcafe71859a683b6ed3f18311634a769550aacf4829b50151b221"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-address-like",
+ "cw-storage-plus 1.1.0",
+ "cw20 1.1.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -26,6 +26,7 @@ cosmwasm-schema = "1.1"
 astroport-circular-buffer = { version = "0.1", path = "../circular_buffer" }
 cw-utils = "1.0"
 cw3 = "1.0"
+cw-asset = "3.0.0"
 
 # optional
 injective-math = { version = "0.1", optional = true }


### PR DESCRIPTION
This pull request would implement type conversation for `Asset` / `AssetInfo` with `cw-asset::Asset` / `cw-asset::AssetInfo`.

Given the popularity of the [cw-asset](https://crates.io/crates/cw-asset), when dealing with astroport, conversions between the two similar types must be done manually, or implement traits to extend one of the two types.

In particular is implemented:
```rust
use cw_asset::{Asset as CwAsset, AssetInfo as CwAssetInfo};

impl From<Asset> for CwAsset;
impl TryFrom<CwAsset> for Asset;
impl From<AssetInfo> for CwAssetInfo;
impl TryFrom<CwAssetInfo> for AssetInfo;
```
New changes are also full tested.
