### PR TITLE
Upgrade MultiTest to version `0.20.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "ap-valkyrie"
@@ -151,7 +151,7 @@ dependencies = [
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw-utils 1.0.3",
  "cw2 0.15.1",
@@ -170,7 +170,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.16.5 (git+https://github.com/astroport-fi/cw-multi-test.git?rev=269a2c829d1ad25d67caa4600f72d2a21fb8fdeb)",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -251,7 +251,7 @@ dependencies = [
  "astroport-vesting",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.16.5 (git+https://github.com/astroport-fi/cw-multi-test?branch=astroport_cozy_fork)",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -277,7 +277,7 @@ dependencies = [
  "astroport-whitelist",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.16.5 (git+https://github.com/astroport-fi/cw-multi-test.git?rev=269a2c829d1ad25d67caa4600f72d2a21fb8fdeb)",
+ "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw20 0.15.1",
  "cw20-base 0.15.1",
@@ -302,7 +302,7 @@ dependencies = [
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
  "cw20 0.15.1",
@@ -329,7 +329,7 @@ dependencies = [
  "astroport-xastro-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.16.5 (git+https://github.com/astroport-fi/cw-multi-test.git?rev=269a2c829d1ad25d67caa4600f72d2a21fb8fdeb)",
+ "cw-multi-test",
  "cw-utils 1.0.3",
  "cw20 0.15.1",
  "cw3",
@@ -346,7 +346,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
  "thiserror",
@@ -360,7 +360,7 @@ dependencies = [
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
  "cw2 0.15.1",
@@ -394,7 +394,7 @@ dependencies = [
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
  "cw20 0.15.1",
@@ -453,7 +453,7 @@ dependencies = [
  "astroport-xastro-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
  "cw20 0.15.1",
@@ -565,13 +565,13 @@ dependencies = [
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.20.0",
+ "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 0.15.1",
  "derivative",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "thiserror",
 ]
 
@@ -625,7 +625,7 @@ dependencies = [
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
  "cw20 0.15.1",
@@ -662,7 +662,7 @@ dependencies = [
  "astroport-xastro-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw-utils 1.0.3",
  "cw2 0.15.1",
@@ -692,7 +692,7 @@ dependencies = [
  "astroport-token",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
  "cw2 0.15.1",
@@ -719,7 +719,7 @@ dependencies = [
  "astroport 3.12.1",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
  "cw20 0.15.1",
@@ -734,7 +734,7 @@ dependencies = [
  "astroport 3.12.1",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.15.1",
+ "cw-multi-test",
  "cw-storage-plus 0.15.1",
  "cw2 0.15.1",
  "cw20 0.15.1",
@@ -747,12 +747,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -835,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9008b6bb9fc80b5277f2fe481c09e828743d9151203e804583eb4c9e15b31d"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "byteorder"
@@ -897,23 +891,23 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bb3c77c3b7ce472056968c745eb501c440fbc07be5004eba02782c35bfbbe3"
+checksum = "9934c79e58d9676edfd592557dee765d2a6ef54c09d5aa2edb06156b00148966"
 dependencies = [
  "digest 0.10.7",
- "ecdsa 0.16.9",
+ "ecdsa",
  "ed25519-zebra",
- "k256 0.13.2",
+ "k256",
  "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea73e9162e6efde00018d55ed0061e93a108b5d6ec4548b4f8ce3c706249687"
+checksum = "bc5e72e330bd3bdab11c52b5ecbdeb6a8697a004c57964caeb5d876f0b088b3c"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -944,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d6864742e3a7662d024b51a94ea81c9af21db6faea2f9a6d2232bb97c6e53e"
+checksum = "ef8666e572a3a2519010dde88c04d16e9339ae751b56b2bb35081fe3f7d6be74"
 dependencies = [
  "base64",
  "bech32",
@@ -994,18 +988,6 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "crypto-bigint"
@@ -1067,64 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.15.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e81b4a7821d5eeba0d23f737c16027b39a600742ca8c32eb980895ffd270f4"
-dependencies = [
- "anyhow",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.15.1",
- "cw-utils 0.15.1",
- "derivative",
- "itertools 0.10.5",
- "prost 0.9.0",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-multi-test"
-version = "0.16.5"
-source = "git+https://github.com/astroport-fi/cw-multi-test?branch=astroport_cozy_fork#08a11aa26f9f35b41f707e803d4cdec38fd2e78d"
-dependencies = [
- "anyhow",
- "cosmwasm-std",
- "cw-storage-plus 1.2.0",
- "cw-utils 1.0.3",
- "derivative",
- "itertools 0.11.0",
- "prost 0.11.9",
- "schemars",
- "serde",
- "sha2 0.10.8",
- "thiserror",
-]
-
-[[package]]
-name = "cw-multi-test"
-version = "0.16.5"
-source = "git+https://github.com/astroport-fi/cw-multi-test.git?rev=269a2c829d1ad25d67caa4600f72d2a21fb8fdeb#269a2c829d1ad25d67caa4600f72d2a21fb8fdeb"
-dependencies = [
- "anyhow",
- "cosmwasm-std",
- "cw-storage-plus 1.2.0",
- "cw-utils 1.0.3",
- "derivative",
- "itertools 0.10.5",
- "k256 0.11.6",
- "prost 0.9.0",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-multi-test"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fff029689ae89127cf6d7655809a68d712f3edbdb9686c70b018ba438b26ca"
+checksum = "cc392a5cb7e778e3f90adbf7faa43c4db7f35b6623224b08886d796718edb875"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1132,7 +1059,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "derivative",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "prost 0.12.3",
  "schemars",
  "serde",
@@ -1421,16 +1348,6 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
@@ -1491,28 +1408,16 @@ checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.8",
+ "der",
  "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1538,39 +1443,19 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest 0.10.7",
- "ff 0.12.1",
- "generic-array",
- "group 0.12.1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
+ "base16ct",
+ "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.0",
+ "ff",
  "generic-array",
- "group 0.13.0",
- "pkcs8 0.10.2",
+ "group",
+ "pkcs8",
  "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1637,16 +1522,6 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "ff"
@@ -1753,22 +1628,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1895,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1910,28 +1774,16 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "k256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
-dependencies = [
- "cfg-if",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "once_cell",
  "sha2 0.10.8",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -2108,22 +1960,12 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.8",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -2187,16 +2029,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
@@ -2213,19 +2045,6 @@ checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
  "prost-derive 0.12.3",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2437,17 +2256,6 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -2534,28 +2342,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.8",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -2568,9 +2362,9 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -2595,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2663,16 +2457,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -2718,22 +2502,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.8",
+ "der",
 ]
 
 [[package]]
@@ -2859,18 +2633,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,3 @@ strip = true
 
 [patch.'https://github.com/astroport-fi/astroport-core']
 astroport = { path = "packages/astroport" }
-
-[patch.crates-io]
-cw-multi-test = { git = "https://github.com/astroport-fi/cw-multi-test.git", rev = "269a2c829d1ad25d67caa4600f72d2a21fb8fdeb" }

--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -35,7 +35,7 @@ cosmwasm-schema = "1.1"
 cw-utils = "1.0.1"
 
 [dev-dependencies]
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"
 astroport-token = { path = "../token" }
 astroport-pair = { path = "../pair" }
 cw20 = "0.15"

--- a/contracts/pair_astro_xastro/Cargo.toml
+++ b/contracts/pair_astro_xastro/Cargo.toml
@@ -36,6 +36,6 @@ cosmwasm-schema = "1.1"
 [dev-dependencies]
 astroport-token = { path = "../token" }
 astroport-factory = { path = "../factory" }
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"
 astroport-staking = { path = "../tokenomics/staking" }
 astroport-xastro-token = { path = "../tokenomics/xastro_token" }

--- a/contracts/pair_concentrated/tests/pair_concentrated_integration.rs
+++ b/contracts/pair_concentrated/tests/pair_concentrated_integration.rs
@@ -868,7 +868,7 @@ fn check_prices() {
 
     let helper = Helper::new(&owner, test_coins.clone(), common_pcl_params()).unwrap();
     let err = helper.query_prices().unwrap_err();
-    assert_eq!(StdError::generic_err("Querier contract error: Generic error: Not implemented.Use { \"observe\": { \"seconds_ago\": ... } } instead.")
+    assert_eq!(StdError::generic_err("Querier contract error: Generic error: Not implemented.Use { \"observe\" : { \"seconds_ago\" : ... } } instead.")
     , err);
 }
 

--- a/contracts/pair_concentrated/tests/pair_concentrated_integration.rs
+++ b/contracts/pair_concentrated/tests/pair_concentrated_integration.rs
@@ -868,7 +868,7 @@ fn check_prices() {
 
     let helper = Helper::new(&owner, test_coins.clone(), common_pcl_params()).unwrap();
     let err = helper.query_prices().unwrap_err();
-    assert_eq!(StdError::generic_err("Querier contract error: Generic error: Not implemented.Use { \"observe\" : { \"seconds_ago\" : ... } } instead.")
+    assert_eq!(StdError::generic_err("Querier contract error: Generic error: Not implemented.Use { \"observe\": { \"seconds_ago\": ... } } instead.")
     , err);
 }
 

--- a/contracts/pair_stable/tests/stablepool_tests.rs
+++ b/contracts/pair_stable/tests/stablepool_tests.rs
@@ -408,7 +408,7 @@ fn check_pool_prices() {
 
     let mut helper = Helper::new(&owner, test_coins.clone(), 100u64, None).unwrap();
     let err = helper.query_prices().unwrap_err();
-    assert_eq!(StdError::generic_err("Querier contract error: Generic error: Not implemented.Use { \"observe\" : { \"seconds_ago\" : ... } } instead.")
+    assert_eq!(StdError::generic_err("Querier contract error: Generic error: Not implemented.Use { \"observe\": { \"seconds_ago\": ... } } instead.")
                , err);
 
     let assets = vec![

--- a/contracts/pair_stable/tests/stablepool_tests.rs
+++ b/contracts/pair_stable/tests/stablepool_tests.rs
@@ -408,7 +408,7 @@ fn check_pool_prices() {
 
     let mut helper = Helper::new(&owner, test_coins.clone(), 100u64, None).unwrap();
     let err = helper.query_prices().unwrap_err();
-    assert_eq!(StdError::generic_err("Querier contract error: Generic error: Not implemented.Use { \"observe\": { \"seconds_ago\": ... } } instead.")
+    assert_eq!(StdError::generic_err("Querier contract error: Generic error: Not implemented.Use { \"observe\" : { \"seconds_ago\" : ... } } instead.")
                , err);
 
     let assets = vec![

--- a/contracts/pair_transmuter/Cargo.toml
+++ b/contracts/pair_transmuter/Cargo.toml
@@ -27,6 +27,6 @@ itertools = "0.12.0"
 anyhow = "1"
 derivative = "2"
 astroport-token = { path = "../token" }
-cw-multi-test = "0.20.0"
+cw-multi-test = "0.20.1"
 astroport-factory = { path = "../factory" }
 astroport-native-coin-registry = { path = "../periphery/native_coin_registry", version = "1" }

--- a/contracts/periphery/fee_granter/Cargo.toml
+++ b/contracts/periphery/fee_granter/Cargo.toml
@@ -20,4 +20,4 @@ thiserror = "1"
 cw2 = "1.0.1"
 
 [dev-dependencies]
-cw-multi-test = { version="0.16.4", features=["stargate"] }
+cw-multi-test = "0.20.1"

--- a/contracts/periphery/fee_granter/tests/fee_granter_integration.rs
+++ b/contracts/periphery/fee_granter/tests/fee_granter_integration.rs
@@ -250,7 +250,7 @@ fn test_update_admins() {
     assert!(
         err.root_cause()
             .to_string()
-          .contains("Unexpected stargate message"),
+            .contains("Unexpected stargate message"),
         "{err}"
     );
 

--- a/contracts/periphery/fee_granter/tests/fee_granter_integration.rs
+++ b/contracts/periphery/fee_granter/tests/fee_granter_integration.rs
@@ -250,7 +250,7 @@ fn test_update_admins() {
     assert!(
         err.root_cause()
             .to_string()
-            .contains("Cannot execute Stargate"),
+          .contains("Unexpected stargate message"),
         "{err}"
     );
 

--- a/contracts/periphery/liquidity_manager/Cargo.toml
+++ b/contracts/periphery/liquidity_manager/Cargo.toml
@@ -22,7 +22,7 @@ astroport-pair-stable = { path = "../../pair_stable", features = ["library"], ve
 astroport-factory = { path = "../../factory", features = ["library"], version = "1" }
 
 [dev-dependencies]
-cw-multi-test = "0.16.4"
+cw-multi-test = "0.20.1"
 astroport-token = { path = "../../token" }
 astroport-native-coin-registry = { path = "../../periphery/native_coin_registry" }
 astroport-generator = { path = "../../tokenomics/generator" }

--- a/contracts/periphery/native-coin-wrapper/Cargo.toml
+++ b/contracts/periphery/native-coin-wrapper/Cargo.toml
@@ -34,5 +34,5 @@ thiserror = { version = "1.0" }
 astroport = { path = "../../../packages/astroport", version = "3" }
 
 [dev-dependencies]
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"
 astroport-token = { path = "../../token" }

--- a/contracts/periphery/native_coin_registry/Cargo.toml
+++ b/contracts/periphery/native_coin_registry/Cargo.toml
@@ -31,4 +31,4 @@ thiserror = { version = "1.0" }
 astroport = { path = "../../../packages/astroport", version = "3" }
 
 [dev-dependencies]
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"

--- a/contracts/periphery/oracle/Cargo.toml
+++ b/contracts/periphery/oracle/Cargo.toml
@@ -33,7 +33,7 @@ astroport-token = { path = "../../token" }
 astroport-factory = { path = "../../factory" }
 astroport-pair = { path = "../../pair" }
 astroport-pair-stable = { path = "../../pair_stable" }
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"
 itertools = "0.10"
 anyhow = "1.0"
 astroport-native-coin-registry = { path = "../../periphery/native_coin_registry" }

--- a/contracts/router/Cargo.toml
+++ b/contracts/router/Cargo.toml
@@ -37,4 +37,4 @@ astroport-factory = { path = "../factory" }
 astroport-token = { path = "../token" }
 astroport-pair = { path = "../pair" }
 anyhow = "1.0"
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"

--- a/contracts/tokenomics/incentives/Cargo.toml
+++ b/contracts/tokenomics/incentives/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1"
 itertools = "0.11"
 
 [dev-dependencies]
-cw-multi-test = { git = "https://github.com/astroport-fi/cw-multi-test", branch = "astroport_cozy_fork" }
+cw-multi-test = "0.20.1"
 anyhow = "1"
 astroport-factory = { path = "../../factory" }
 astroport-pair = { path = "../../pair" }

--- a/contracts/tokenomics/incentives/tests/helper/helper.rs
+++ b/contracts/tokenomics/incentives/tests/helper/helper.rs
@@ -238,7 +238,7 @@ pub struct Helper {
 impl Helper {
     pub fn new(owner: &str, astro: &AssetInfo) -> AnyResult<Self> {
         let mut app = AppBuilder::new()
-          .with_wasm(WasmKeeper::new().with_address_generator(TestAddr))
+            .with_wasm(WasmKeeper::new().with_address_generator(TestAddr))
             .with_api(TestApi::new())
             .with_block(BlockInfo {
                 height: 1,

--- a/contracts/tokenomics/incentives/tests/helper/helper.rs
+++ b/contracts/tokenomics/incentives/tests/helper/helper.rs
@@ -192,7 +192,13 @@ impl TestAddr {
 }
 
 impl AddressGenerator for TestAddr {
-    fn next_address(&self, storage: &mut dyn Storage) -> Addr {
+    fn contract_address(
+        &self,
+        _api: &dyn Api,
+        storage: &mut dyn Storage,
+        _code_id: u64,
+        _instance_id: u64,
+    ) -> AnyResult<Addr> {
         let count = if let Some(next) = storage.get(Self::COUNT_KEY) {
             u64::from_be_bytes(next.as_slice().try_into().unwrap()) + 1
         } else {
@@ -200,7 +206,10 @@ impl AddressGenerator for TestAddr {
         };
         storage.set(Self::COUNT_KEY, &count.to_be_bytes());
 
-        Addr::unchecked(format!("{}_contract{count}", Self::ADDR_PREFIX))
+        Ok(Addr::unchecked(format!(
+            "{}_contract{count}",
+            Self::ADDR_PREFIX
+        )))
     }
 }
 
@@ -229,9 +238,7 @@ pub struct Helper {
 impl Helper {
     pub fn new(owner: &str, astro: &AssetInfo) -> AnyResult<Self> {
         let mut app = AppBuilder::new()
-            .with_wasm::<FailingModule<_, _, Empty>, WasmKeeper<_, _>>(
-                WasmKeeper::new_with_custom_address_generator(TestAddr),
-            )
+          .with_wasm(WasmKeeper::new().with_address_generator(TestAddr))
             .with_api(TestApi::new())
             .with_block(BlockInfo {
                 height: 1,

--- a/contracts/tokenomics/maker/Cargo.toml
+++ b/contracts/tokenomics/maker/Cargo.toml
@@ -34,7 +34,7 @@ astro-satellite-package = { git = "https://github.com/astroport-fi/astroport_ibc
 astroport-token = { path = "../../token" }
 astroport-factory = { path = "../../factory" }
 astroport-pair = { path = "../../pair" }
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"
 astroport-pair-stable = { path = "../../pair_stable" }
 astroport-governance = { git = "https://github.com/astroport-fi/astroport-governance" }
 astroport-escrow-fee-distributor = { git = "https://github.com/astroport-fi/astroport-governance" }

--- a/contracts/tokenomics/staking/Cargo.toml
+++ b/contracts/tokenomics/staking/Cargo.toml
@@ -33,4 +33,4 @@ cw-utils = "1.0.1"
 [dev-dependencies]
 astroport-token = { path = "../../token" }
 astroport-xastro-token = { path = "../../tokenomics/xastro_token" }
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"

--- a/contracts/tokenomics/vesting/Cargo.toml
+++ b/contracts/tokenomics/vesting/Cargo.toml
@@ -23,5 +23,5 @@ cw-utils = "0.15"
 cosmwasm-schema = { version = "1.1", default-features = false }
 
 [dev-dependencies]
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"
 astroport-token = { path = "../../token" }

--- a/contracts/tokenomics/xastro_outpost_token/Cargo.toml
+++ b/contracts/tokenomics/xastro_outpost_token/Cargo.toml
@@ -28,4 +28,4 @@ snafu = { version = "0.6" }
 cosmwasm-schema = "1.1"
 
 [dev-dependencies]
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"

--- a/contracts/tokenomics/xastro_token/Cargo.toml
+++ b/contracts/tokenomics/xastro_token/Cargo.toml
@@ -28,4 +28,4 @@ snafu = { version = "0.6" }
 cosmwasm-schema = "1.1"
 
 [dev-dependencies]
-cw-multi-test = "0.15"
+cw-multi-test = "0.20.1"

--- a/packages/astroport_mocks/Cargo.toml
+++ b/packages/astroport_mocks/Cargo.toml
@@ -26,7 +26,7 @@ astroport-whitelist = { path = "../../contracts/whitelist" }
 astroport-xastro-token = { path = "../../contracts/tokenomics/xastro_token" }
 cosmwasm-schema = "1.2.5"
 cosmwasm-std = "1.2.5"
-cw-multi-test = { git = "https://github.com/astroport-fi/cw-multi-test.git", rev = "269a2c829d1ad25d67caa4600f72d2a21fb8fdeb" }
+cw-multi-test = "0.20.1"
 injective-cosmwasm = "0.2"
 schemars = "0.8.1"
 serde = "1.0"


### PR DESCRIPTION
Hi all,

there was a PR reported to **MultiTest** by @ShadoySV: https://github.com/CosmWasm/cw-multi-test/pull/46

We have fixed it and applied the patch in version **0.16.6** of **MultiTest**. But it looks like it could be upgraded to version **0.20.1** and even later to planned version **1.0.0** (1.0.0-rc.2 is already published).

This PR contains "all and only" changes required to upgrade **MultiTest** to version **0.20.1** and unifies this dependency in the whole project.

If you find this PR valuable, and would like to upgrade later to version 1.0.0 then just leave a comment on this PR, we will prepare a PR with all changes needed as a **Thank you** for your engagement in making **MultiTest** better.

Changes in this PR were tested like this:
```shell
$ cargo +1.68.0-x86_64-unknown-linux-gnu nextest run --workspace
(... all test names and statuses...)
------------
     Summary [   2.906s] 350 tests run: 350 passed, 10 skipped
```
Regards,
Darek