### PR TITLE
Upgraded MultiTest to version `1.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "bigint"
 version = "4.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,7 +949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8666e572a3a2519010dde88c04d16e9339ae751b56b2bb35081fe3f7d6be74"
 dependencies = [
  "base64",
- "bech32",
+ "bech32 0.9.1",
  "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
@@ -1049,12 +1055,12 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.20.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc392a5cb7e778e3f90adbf7faa43c4db7f35b6623224b08886d796718edb875"
+checksum = "f8c6c2f2ee4b29e03fd709f4278a70a11c816690f2c992a9c980303ebda574f8"
 dependencies = [
  "anyhow",
- "bech32",
+ "bech32 0.11.0",
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",

--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -7,9 +7,9 @@ description = "Astroport factory contract - pair contract generator and director
 license = "MIT"
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -35,7 +35,7 @@ cosmwasm-schema = "1.1"
 cw-utils = "1.0.1"
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 astroport-token = { path = "../token" }
 astroport-pair = { path = "../pair" }
 cw20 = "0.15"

--- a/contracts/pair_astro_xastro/Cargo.toml
+++ b/contracts/pair_astro_xastro/Cargo.toml
@@ -7,9 +7,9 @@ description = "The Astroport ASTRO-xASTRO pair contract implementation"
 license = "MIT"
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -36,6 +36,6 @@ cosmwasm-schema = "1.1"
 [dev-dependencies]
 astroport-token = { path = "../token" }
 astroport-factory = { path = "../factory" }
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 astroport-staking = { path = "../tokenomics/staking" }
 astroport-xastro-token = { path = "../tokenomics/xastro_token" }

--- a/contracts/pair_transmuter/Cargo.toml
+++ b/contracts/pair_transmuter/Cargo.toml
@@ -27,6 +27,6 @@ itertools = "0.12.0"
 anyhow = "1"
 derivative = "2"
 astroport-token = { path = "../token" }
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 astroport-factory = { path = "../factory" }
 astroport-native-coin-registry = { path = "../periphery/native_coin_registry", version = "1" }

--- a/contracts/periphery/fee_granter/Cargo.toml
+++ b/contracts/periphery/fee_granter/Cargo.toml
@@ -20,4 +20,4 @@ thiserror = "1"
 cw2 = "1.0.1"
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"

--- a/contracts/periphery/fee_granter/tests/fee_granter_integration.rs
+++ b/contracts/periphery/fee_granter/tests/fee_granter_integration.rs
@@ -248,9 +248,7 @@ fn test_update_admins() {
         )
         .unwrap_err();
     assert!(
-        err.root_cause()
-            .to_string()
-            .contains("Unexpected stargate message"),
+        err.root_cause().to_string().contains("Unexpected exec msg"),
         "{err}"
     );
 

--- a/contracts/periphery/liquidity_manager/Cargo.toml
+++ b/contracts/periphery/liquidity_manager/Cargo.toml
@@ -22,7 +22,7 @@ astroport-pair-stable = { path = "../../pair_stable", features = ["library"], ve
 astroport-factory = { path = "../../factory", features = ["library"], version = "1" }
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 astroport-token = { path = "../../token" }
 astroport-native-coin-registry = { path = "../../periphery/native_coin_registry" }
 astroport-generator = { path = "../../tokenomics/generator" }

--- a/contracts/periphery/native-coin-wrapper/Cargo.toml
+++ b/contracts/periphery/native-coin-wrapper/Cargo.toml
@@ -7,9 +7,9 @@ homepage = "https://astroport.fi"
 edition = "2021"
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -34,5 +34,5 @@ thiserror = { version = "1.0" }
 astroport = { path = "../../../packages/astroport", version = "3" }
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 astroport-token = { path = "../../token" }

--- a/contracts/periphery/native-coin-wrapper/tests/integration.rs
+++ b/contracts/periphery/native-coin-wrapper/tests/integration.rs
@@ -254,7 +254,10 @@ fn check_wrap_and_unwrap() {
             &[],
         )
         .unwrap_err();
-    assert_eq!("Cannot Sub with 0 and 10", err.root_cause().to_string());
+    assert_eq!(
+        "Overflow: Cannot Sub with 0 and 10",
+        err.root_cause().to_string()
+    );
 
     // check user1's wrapped cw20 token balance
     assert_eq!(

--- a/contracts/periphery/native_coin_registry/Cargo.toml
+++ b/contracts/periphery/native_coin_registry/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Astroport"]
 edition = "2021"
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -31,4 +31,4 @@ thiserror = { version = "1.0" }
 astroport = { path = "../../../packages/astroport", version = "3" }
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"

--- a/contracts/periphery/oracle/Cargo.toml
+++ b/contracts/periphery/oracle/Cargo.toml
@@ -33,7 +33,7 @@ astroport-token = { path = "../../token" }
 astroport-factory = { path = "../../factory" }
 astroport-pair = { path = "../../pair" }
 astroport-pair-stable = { path = "../../pair_stable" }
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 itertools = "0.10"
 anyhow = "1.0"
 astroport-native-coin-registry = { path = "../../periphery/native_coin_registry" }

--- a/contracts/router/Cargo.toml
+++ b/contracts/router/Cargo.toml
@@ -37,4 +37,4 @@ astroport-factory = { path = "../factory" }
 astroport-token = { path = "../token" }
 astroport-pair = { path = "../pair" }
 anyhow = "1.0"
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"

--- a/contracts/tokenomics/generator/tests/integration.rs
+++ b/contracts/tokenomics/generator/tests/integration.rs
@@ -1282,7 +1282,7 @@ fn generator_without_reward_proxies() {
             .unwrap_err()
             .root_cause()
             .to_string(),
-        "Cannot Sub with 9 and 10".to_string()
+        "Overflow: Cannot Sub with 9 and 10".to_string()
     );
 
     mint_tokens(&mut app, pair_cny_eur.clone(), &lp_cny_eur, &user1, 1);
@@ -1955,7 +1955,7 @@ fn generator_with_vkr_reward_proxy() {
         .unwrap_err();
     assert_eq!(
         err.root_cause().to_string(),
-        "Cannot Sub with 9 and 10".to_string()
+        "Overflow: Cannot Sub with 9 and 10".to_string()
     );
 
     mint_tokens(&mut app, pair_val_eur.clone(), &lp_val_eur, &user1, 1);

--- a/contracts/tokenomics/incentives/Cargo.toml
+++ b/contracts/tokenomics/incentives/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1"
 itertools = "0.11"
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 anyhow = "1"
 astroport-factory = { path = "../../factory" }
 astroport-pair = { path = "../../pair" }

--- a/contracts/tokenomics/maker/Cargo.toml
+++ b/contracts/tokenomics/maker/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Astroport"]
 edition = "2021"
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -34,7 +34,7 @@ astro-satellite-package = { git = "https://github.com/astroport-fi/astroport_ibc
 astroport-token = { path = "../../token" }
 astroport-factory = { path = "../../factory" }
 astroport-pair = { path = "../../pair" }
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 astroport-pair-stable = { path = "../../pair_stable" }
 astroport-governance = { git = "https://github.com/astroport-fi/astroport-governance" }
 astroport-escrow-fee-distributor = { git = "https://github.com/astroport-fi/astroport-governance" }

--- a/contracts/tokenomics/staking/Cargo.toml
+++ b/contracts/tokenomics/staking/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Astroport"]
 edition = "2021"
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -33,4 +33,4 @@ cw-utils = "1.0.1"
 [dev-dependencies]
 astroport-token = { path = "../../token" }
 astroport-xastro-token = { path = "../../tokenomics/xastro_token" }
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"

--- a/contracts/tokenomics/staking/tests/integration.rs
+++ b/contracts/tokenomics/staking/tests/integration.rs
@@ -523,7 +523,7 @@ fn should_not_allow_withdraw_more_than_what_you_have() {
 
     assert_eq!(
         res.root_cause().to_string(),
-        "Cannot Sub with 1000 and 2000"
+        "Overflow: Cannot Sub with 1000 and 2000"
     );
 }
 

--- a/contracts/tokenomics/vesting/Cargo.toml
+++ b/contracts/tokenomics/vesting/Cargo.toml
@@ -23,5 +23,5 @@ cw-utils = "0.15"
 cosmwasm-schema = { version = "1.1", default-features = false }
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 astroport-token = { path = "../../token" }

--- a/contracts/tokenomics/vesting/tests/integration.rs
+++ b/contracts/tokenomics/vesting/tests/integration.rs
@@ -469,7 +469,10 @@ fn register_vesting_accounts() {
             &[],
         )
         .unwrap_err();
-    assert_eq!(res.root_cause().to_string(), "Cannot Sub with 0 and 100");
+    assert_eq!(
+        res.root_cause().to_string(),
+        "Overflow: Cannot Sub with 0 and 100"
+    );
 
     let res = app
         .execute_contract(owner.clone(), noname_token_instance.clone(), &msg, &[])

--- a/contracts/tokenomics/xastro_outpost_token/Cargo.toml
+++ b/contracts/tokenomics/xastro_outpost_token/Cargo.toml
@@ -28,4 +28,4 @@ snafu = { version = "0.6" }
 cosmwasm-schema = "1.1"
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"

--- a/contracts/tokenomics/xastro_token/Cargo.toml
+++ b/contracts/tokenomics/xastro_token/Cargo.toml
@@ -28,4 +28,4 @@ snafu = { version = "0.6" }
 cosmwasm-schema = "1.1"
 
 [dev-dependencies]
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"

--- a/packages/astroport_mocks/Cargo.toml
+++ b/packages/astroport_mocks/Cargo.toml
@@ -26,7 +26,7 @@ astroport-whitelist = { path = "../../contracts/whitelist" }
 astroport-xastro-token = { path = "../../contracts/tokenomics/xastro_token" }
 cosmwasm-schema = "1.2.5"
 cosmwasm-std = "1.2.5"
-cw-multi-test = "0.20.1"
+cw-multi-test = "1.0.0"
 injective-cosmwasm = "0.2"
 schemars = "0.8.1"
 serde = "1.0"

--- a/packages/astroport_mocks/src/coin_registry.rs
+++ b/packages/astroport_mocks/src/coin_registry.rs
@@ -1,16 +1,13 @@
-use std::fmt::Debug;
-
 use astroport::native_coin_registry::{ExecuteMsg, InstantiateMsg};
-use cosmwasm_std::{Addr, Api, CustomQuery, Storage};
+use cosmwasm_std::{Addr, Api, CustomMsg, CustomQuery, Storage};
 use cw_multi_test::{
-    AppResponse, Bank, ContractWrapper, Distribution, Executor, Gov, Ibc, Module, Staking,
+    AppResponse, Bank, ContractWrapper, Distribution, Executor, Gov, Ibc, Module, Staking, Stargate,
 };
-use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::{astroport_address, WKApp, ASTROPORT};
 
-pub fn store_code<B, A, S, C, X, D, I, G>(app: &WKApp<B, A, S, C, X, D, I, G>) -> u64
+pub fn store_code<B, A, S, C, X, D, I, G, T>(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> u64
 where
     B: Bank,
     A: Api,
@@ -20,7 +17,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     use astroport_native_coin_registry as cnt;
@@ -33,11 +31,11 @@ where
     app.borrow_mut().store_code(contract)
 }
 
-pub struct MockCoinRegistryBuilder<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockCoinRegistryBuilder<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
 }
 
-impl<B, A, S, C, X, D, I, G> MockCoinRegistryBuilder<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockCoinRegistryBuilder<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -47,13 +45,14 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
-    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G>) -> Self {
+    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> Self {
         Self { app: app.clone() }
     }
-    pub fn instantiate(self) -> MockCoinRegistry<B, A, S, C, X, D, I, G> {
+    pub fn instantiate(self) -> MockCoinRegistry<B, A, S, C, X, D, I, G, T> {
         let code_id = store_code(&self.app);
         let astroport = astroport_address();
 
@@ -91,12 +90,12 @@ where
     }
 }
 
-pub struct MockCoinRegistry<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockCoinRegistry<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
     pub address: Addr,
 }
 
-impl<B, A, S, C, X, D, I, G> MockCoinRegistry<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockCoinRegistry<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -106,7 +105,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     pub fn add(&self, coins: Vec<(String, u8)>) -> AppResponse {

--- a/packages/astroport_mocks/src/factory.rs
+++ b/packages/astroport_mocks/src/factory.rs
@@ -1,5 +1,4 @@
 use anyhow::Result as AnyResult;
-use std::fmt::Debug;
 
 use astroport::{
     asset::{AssetInfo, PairInfo},
@@ -7,11 +6,10 @@ use astroport::{
     pair::StablePoolParams,
     pair_concentrated::ConcentratedPoolParams,
 };
-use cosmwasm_std::{to_json_binary, Addr, Api, CustomQuery, Decimal, Storage};
+use cosmwasm_std::{to_json_binary, Addr, Api, CustomMsg, CustomQuery, Decimal, Storage};
 use cw_multi_test::{
-    AppResponse, Bank, ContractWrapper, Distribution, Executor, Gov, Ibc, Module, Staking,
+    AppResponse, Bank, ContractWrapper, Distribution, Executor, Gov, Ibc, Module, Staking, Stargate,
 };
-use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::{
@@ -19,7 +17,7 @@ use crate::{
     MockStablePair, MockXykPair, WKApp, ASTROPORT,
 };
 
-pub fn store_code<B, A, S, C, X, D, I, G>(app: &WKApp<B, A, S, C, X, D, I, G>) -> u64
+pub fn store_code<B, A, S, C, X, D, I, G, T>(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> u64
 where
     B: Bank,
     A: Api,
@@ -29,7 +27,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     use astroport_factory as cnt;
@@ -45,11 +44,11 @@ where
     app.borrow_mut().store_code(contract)
 }
 
-pub struct MockFactoryBuilder<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockFactoryBuilder<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
 }
 
-impl<B, A, S, C, X, D, I, G> MockFactoryBuilder<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockFactoryBuilder<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -59,14 +58,15 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
-    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G>) -> Self {
+    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> Self {
         Self { app: app.clone() }
     }
 
-    pub fn instantiate(self) -> MockFactory<B, A, S, C, X, D, I, G> {
+    pub fn instantiate(self) -> MockFactory<B, A, S, C, X, D, I, G, T> {
         let code_id = store_code(&self.app);
         let astroport = astroport_address();
 
@@ -137,14 +137,14 @@ where
     }
 }
 
-pub struct MockFactory<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockFactory<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
     pub address: Addr,
 }
 
-pub type MockFactoryOpt<B, A, S, C, X, D, I, G> = Option<MockFactory<B, A, S, C, X, D, I, G>>;
+pub type MockFactoryOpt<B, A, S, C, X, D, I, G, T> = Option<MockFactory<B, A, S, C, X, D, I, G, T>>;
 
-impl<B, A, S, C, X, D, I, G> MockFactory<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockFactory<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -154,7 +154,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     pub fn whitelist_code_id(&self) -> u64 {
@@ -182,7 +183,7 @@ where
     pub fn instantiate_xyk_pair(
         &self,
         asset_infos: &[AssetInfo],
-    ) -> MockXykPair<B, A, S, C, X, D, I, G> {
+    ) -> MockXykPair<B, A, S, C, X, D, I, G, T> {
         let astroport = astroport_address();
 
         self.app
@@ -222,7 +223,7 @@ where
         &self,
         asset_infos: &[AssetInfo],
         init_params: Option<&StablePoolParams>,
-    ) -> MockStablePair<B, A, S, C, X, D, I, G> {
+    ) -> MockStablePair<B, A, S, C, X, D, I, G, T> {
         let astroport = astroport_address();
 
         let default_params = StablePoolParams {
@@ -264,7 +265,7 @@ where
         }
     }
 
-    pub fn coin_registry(&self) -> MockCoinRegistry<B, A, S, C, X, D, I, G> {
+    pub fn coin_registry(&self) -> MockCoinRegistry<B, A, S, C, X, D, I, G, T> {
         let config: ConfigResponse = self
             .app
             .borrow()
@@ -283,7 +284,7 @@ where
         &self,
         asset_infos: &[AssetInfo],
         init_params: Option<&ConcentratedPoolParams>,
-    ) -> MockConcentratedPair<B, A, S, C, X, D, I, G> {
+    ) -> MockConcentratedPair<B, A, S, C, X, D, I, G, T> {
         let astroport = astroport_address();
 
         let default_params = ConcentratedPoolParams {

--- a/packages/astroport_mocks/src/lib.rs
+++ b/packages/astroport_mocks/src/lib.rs
@@ -38,6 +38,8 @@ pub fn astroport_address() -> Addr {
     Addr::unchecked(ASTROPORT)
 }
 
-pub type WKApp<B, A, S, C, X, D, I, G> = Rc<
-    RefCell<App<B, A, S, C, WasmKeeper<<C as Module>::ExecT, <C as Module>::QueryT>, X, D, I, G>>,
+pub type WKApp<B, A, S, C, X, D, I, G, T> = Rc<
+    RefCell<
+        App<B, A, S, C, WasmKeeper<<C as Module>::ExecT, <C as Module>::QueryT>, X, D, I, G, T>,
+    >,
 >;

--- a/packages/astroport_mocks/src/pair_stable.rs
+++ b/packages/astroport_mocks/src/pair_stable.rs
@@ -1,19 +1,16 @@
-use std::fmt::Debug;
-
 use astroport::{
     asset::{Asset, AssetInfo, PairInfo},
     pair::{QueryMsg, StablePoolParams},
 };
-use cosmwasm_std::{Addr, Api, CustomQuery, Decimal, Storage};
-use cw_multi_test::{Bank, ContractWrapper, Distribution, Gov, Ibc, Module, Staking};
-use schemars::JsonSchema;
+use cosmwasm_std::{Addr, Api, CustomMsg, CustomQuery, Decimal, Storage};
+use cw_multi_test::{Bank, ContractWrapper, Distribution, Gov, Ibc, Module, Staking, Stargate};
 use serde::de::DeserializeOwned;
 
 use crate::{
     factory::MockFactoryOpt, MockFactory, MockFactoryBuilder, MockToken, MockXykPair, WKApp,
 };
 
-pub fn store_code<B, A, S, C, X, D, I, G>(app: &WKApp<B, A, S, C, X, D, I, G>) -> u64
+pub fn store_code<B, A, S, C, X, D, I, G, T>(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> u64
 where
     B: Bank,
     A: Api,
@@ -23,7 +20,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     use astroport_pair_stable as cnt;
@@ -39,13 +37,13 @@ where
     app.borrow_mut().store_code(contract)
 }
 
-pub struct MockStablePairBuilder<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockStablePairBuilder<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
     pub asset_infos: Vec<AssetInfo>,
-    pub factory: MockFactoryOpt<B, A, S, C, X, D, I, G>,
+    pub factory: MockFactoryOpt<B, A, S, C, X, D, I, G, T>,
 }
 
-impl<B, A, S, C, X, D, I, G> MockStablePairBuilder<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockStablePairBuilder<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -55,10 +53,11 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
-    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G>) -> Self {
+    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> Self {
         Self {
             app: app.clone(),
             asset_infos: Default::default(),
@@ -66,7 +65,7 @@ where
         }
     }
 
-    pub fn with_factory(mut self, factory: &MockFactory<B, A, S, C, X, D, I, G>) -> Self {
+    pub fn with_factory(mut self, factory: &MockFactory<B, A, S, C, X, D, I, G, T>) -> Self {
         self.factory = Some(MockFactory {
             app: self.app.clone(),
             address: factory.address.clone(),
@@ -83,7 +82,7 @@ where
     pub fn instantiate(
         self,
         params: Option<&StablePoolParams>,
-    ) -> MockStablePair<B, A, S, C, X, D, I, G> {
+    ) -> MockStablePair<B, A, S, C, X, D, I, G, T> {
         let factory = self
             .factory
             .unwrap_or_else(|| MockFactoryBuilder::new(&self.app).instantiate());
@@ -92,12 +91,12 @@ where
     }
 }
 
-pub struct MockStablePair<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockStablePair<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
     pub address: Addr,
 }
 
-impl<B, A, S, C, X, D, I, G> MockStablePair<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockStablePair<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -107,10 +106,11 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
-    pub fn lp_token(&self) -> MockToken<B, A, S, C, X, D, I, G> {
+    pub fn lp_token(&self) -> MockToken<B, A, S, C, X, D, I, G, T> {
         let res: PairInfo = self
             .app
             .borrow()

--- a/packages/astroport_mocks/src/vesting.rs
+++ b/packages/astroport_mocks/src/vesting.rs
@@ -1,17 +1,16 @@
-use std::fmt::Debug;
-
 use crate::{astroport_address, MockTokenBuilder, WKApp, ASTROPORT};
 use astroport::{
     asset::AssetInfo,
     vesting::QueryMsg,
     vesting::{ConfigResponse, InstantiateMsg},
 };
-use cosmwasm_std::{Addr, Api, CustomQuery, Storage};
-use cw_multi_test::{Bank, ContractWrapper, Distribution, Executor, Gov, Ibc, Module, Staking};
-use schemars::JsonSchema;
+use cosmwasm_std::{Addr, Api, CustomMsg, CustomQuery, Storage};
+use cw_multi_test::{
+    Bank, ContractWrapper, Distribution, Executor, Gov, Ibc, Module, Staking, Stargate,
+};
 use serde::de::DeserializeOwned;
 
-pub fn store_code<B, A, S, C, X, D, I, G>(app: &WKApp<B, A, S, C, X, D, I, G>) -> u64
+pub fn store_code<B, A, S, C, X, D, I, G, T>(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> u64
 where
     B: Bank,
     A: Api,
@@ -21,7 +20,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     use astroport_vesting as cnt;
@@ -34,12 +34,12 @@ where
     app.borrow_mut().store_code(contract)
 }
 
-pub struct MockVestingBuilder<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockVestingBuilder<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
     pub astro_token: Option<AssetInfo>,
 }
 
-impl<B, A, S, C, X, D, I, G> MockVestingBuilder<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockVestingBuilder<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -49,10 +49,11 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
-    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G>) -> Self {
+    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> Self {
         Self {
             app: app.clone(),
             astro_token: None,
@@ -64,7 +65,7 @@ where
         self
     }
 
-    pub fn instantiate(self) -> MockVesting<B, A, S, C, X, D, I, G> {
+    pub fn instantiate(self) -> MockVesting<B, A, S, C, X, D, I, G, T> {
         let code_id = store_code(&self.app);
         let astroport = astroport_address();
 
@@ -97,12 +98,12 @@ where
     }
 }
 
-pub struct MockVesting<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockVesting<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
     pub address: Addr,
 }
 
-impl<B, A, S, C, X, D, I, G> MockVesting<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockVesting<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -112,7 +113,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     pub fn vesting_token_info(&self) -> AssetInfo {

--- a/packages/astroport_mocks/src/whitelist.rs
+++ b/packages/astroport_mocks/src/whitelist.rs
@@ -1,13 +1,10 @@
-use std::fmt::Debug;
-
-use cosmwasm_std::{Api, CustomQuery, Storage};
-use cw_multi_test::{Bank, ContractWrapper, Distribution, Gov, Ibc, Module, Staking};
-use schemars::JsonSchema;
+use cosmwasm_std::{Api, CustomMsg, CustomQuery, Storage};
+use cw_multi_test::{Bank, ContractWrapper, Distribution, Gov, Ibc, Module, Staking, Stargate};
 use serde::de::DeserializeOwned;
 
 use crate::WKApp;
 
-pub fn store_code<B, A, S, C, X, D, I, G>(app: &WKApp<B, A, S, C, X, D, I, G>) -> u64
+pub fn store_code<B, A, S, C, X, D, I, G, T>(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> u64
 where
     B: Bank,
     A: Api,
@@ -17,7 +14,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     use astroport_whitelist as cnt;

--- a/packages/astroport_mocks/src/xastro.rs
+++ b/packages/astroport_mocks/src/xastro.rs
@@ -1,17 +1,16 @@
-use std::fmt::Debug;
-
 use astroport::{
     asset::AssetInfo,
     token::{InstantiateMsg, MinterResponse},
 };
-use cosmwasm_std::{Addr, Api, CustomQuery, Storage};
-use cw_multi_test::{Bank, ContractWrapper, Distribution, Executor, Gov, Ibc, Module, Staking};
-use schemars::JsonSchema;
+use cosmwasm_std::{Addr, Api, CustomMsg, CustomQuery, Storage};
+use cw_multi_test::{
+    Bank, ContractWrapper, Distribution, Executor, Gov, Ibc, Module, Staking, Stargate,
+};
 use serde::de::DeserializeOwned;
 
 use crate::{astroport_address, MockToken, WKApp, ASTROPORT};
 
-pub fn store_code<B, A, S, C, X, D, I, G>(app: &WKApp<B, A, S, C, X, D, I, G>) -> u64
+pub fn store_code<B, A, S, C, X, D, I, G, T>(app: &WKApp<B, A, S, C, X, D, I, G, T>) -> u64
 where
     B: Bank,
     A: Api,
@@ -21,7 +20,8 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     use astroport_xastro_token as cnt;
@@ -34,12 +34,12 @@ where
     app.borrow_mut().store_code(contract)
 }
 
-pub struct MockXastroBuilder<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockXastroBuilder<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
     pub symbol: String,
 }
 
-impl<B, A, S, C, X, D, I, G> MockXastroBuilder<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> MockXastroBuilder<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -49,17 +49,18 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
-    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G>, symbol: &str) -> Self {
+    pub fn new(app: &WKApp<B, A, S, C, X, D, I, G, T>, symbol: &str) -> Self {
         Self {
             app: app.clone(),
             symbol: symbol.into(),
         }
     }
 
-    pub fn instantiate(self) -> MockXastro<B, A, S, C, X, D, I, G> {
+    pub fn instantiate(self) -> MockXastro<B, A, S, C, X, D, I, G, T> {
         let code_id = store_code(&self.app);
         let astroport = astroport_address();
 
@@ -97,14 +98,14 @@ where
     }
 }
 
-pub struct MockXastro<B, A, S, C: Module, X, D, I, G> {
-    pub app: WKApp<B, A, S, C, X, D, I, G>,
+pub struct MockXastro<B, A, S, C: Module, X, D, I, G, T> {
+    pub app: WKApp<B, A, S, C, X, D, I, G, T>,
     pub address: Addr,
-    pub token: MockToken<B, A, S, C, X, D, I, G>,
+    pub token: MockToken<B, A, S, C, X, D, I, G, T>,
 }
 
-impl<B, A, S, C, X, D, I, G> TryFrom<(WKApp<B, A, S, C, X, D, I, G>, &AssetInfo)>
-    for MockXastro<B, A, S, C, X, D, I, G>
+impl<B, A, S, C, X, D, I, G, T> TryFrom<(WKApp<B, A, S, C, X, D, I, G, T>, &AssetInfo)>
+    for MockXastro<B, A, S, C, X, D, I, G, T>
 where
     B: Bank,
     A: Api,
@@ -114,13 +115,14 @@ where
     D: Distribution,
     I: Ibc,
     G: Gov,
-    C::ExecT: Clone + Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
+    T: Stargate,
+    C::ExecT: CustomMsg + DeserializeOwned + 'static,
     C::QueryT: CustomQuery + DeserializeOwned + 'static,
 {
     type Error = String;
     fn try_from(
-        value: (WKApp<B, A, S, C, X, D, I, G>, &AssetInfo),
-    ) -> Result<MockXastro<B, A, S, C, X, D, I, G>, Self::Error> {
+        value: (WKApp<B, A, S, C, X, D, I, G, T>, &AssetInfo),
+    ) -> Result<MockXastro<B, A, S, C, X, D, I, G, T>, Self::Error> {
         match value.1 {
             AssetInfo::Token { contract_addr } => Ok(MockXastro {
                 app: value.0.clone(),


### PR DESCRIPTION
Hi @epanchee ,

the version **1.0.0** of **MultiTest** was released, so this is the promised PR with upgrading **MultiTest** to version **1.0.0**.

Since now, there will be two major lines of **MultiTest**:
- line **1.x.y** - dedicated for testing smart contracts based on `cosmwasm-std` **1.x**
- line **2.x.y** - dedicated for testing smart contracts based on `cosmwasm-std` **2.x**

This PR was tested this way:
```shell
$ cargo +1.68.0-x86_64-unknown-linux-gnu nextest run --workspace
    Starting 350 tests across 62 binaries (10 skipped)
        PASS [   0.005s] astroport asset::tests::from_cw20coinverified_for_asset
        PASS [   0.005s] astroport asset::tests::cw20_asset_info
       ...
        PASS [   0.695s] astroport-pair-stable testing::constant_product_swap_no_fee
        PASS [   2.119s] astroport-pair-concentrated::pair_concentrated_integration check_small_trades
        PASS [   2.694s] astroport-pair-concentrated::pair_concentrated_integration check_small_trades_18decimals
------------
     Summary [   3.015s] 350 tests run: 350 passed, 10 skipped
```