### PR TITLE
feat(coin registry): permissionless add decimals endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "astroport-circular-buffer 0.2.0",
  "cosmos-sdk-proto 0.19.0",
@@ -177,7 +177,7 @@ name = "astroport-factory"
 version = "1.8.0"
 dependencies = [
  "anyhow",
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "astroport-pair 2.0.1",
  "astroport-test",
  "cosmwasm-schema",
@@ -268,14 +268,15 @@ dependencies = [
 
 [[package]]
 name = "astroport-native-coin-registry"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
- "astroport 3.12.2",
+ "astroport 5.2.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 1.2.0",
- "cw-storage-plus 0.15.1",
+ "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
+ "itertools 0.12.1",
  "thiserror",
 ]
 
@@ -321,7 +322,7 @@ dependencies = [
 name = "astroport-pair"
 version = "2.0.1"
 dependencies = [
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "astroport-factory",
  "astroport-incentives",
  "astroport-test",
@@ -344,7 +345,7 @@ name = "astroport-pair-concentrated"
 version = "4.0.1"
 dependencies = [
  "anyhow",
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "astroport-circular-buffer 0.2.0",
  "astroport-factory",
  "astroport-incentives",
@@ -393,7 +394,7 @@ name = "astroport-pair-stable"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "astroport-circular-buffer 0.2.0",
  "astroport-factory",
  "astroport-incentives",
@@ -419,7 +420,7 @@ name = "astroport-pair-transmuter"
 version = "1.1.1"
 dependencies = [
  "anyhow",
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-test",
@@ -439,7 +440,7 @@ dependencies = [
 name = "astroport-pair-xyk-sale-tax"
 version = "2.0.1"
 dependencies = [
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "astroport-factory",
  "astroport-incentives",
  "astroport-pair 1.3.3",
@@ -465,7 +466,7 @@ name = "astroport-pcl-common"
 version = "2.0.1"
 dependencies = [
  "anyhow",
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "astroport-factory",
  "astroport-test",
  "cosmwasm-schema",
@@ -518,7 +519,7 @@ name = "astroport-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 1.0.0",
@@ -547,7 +548,7 @@ dependencies = [
 name = "astroport-tokenfactory-tracker"
 version = "2.0.0"
 dependencies = [
- "astroport 5.1.0",
+ "astroport 5.2.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 0.20.0",
@@ -628,7 +629,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -698,7 +699,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -711,7 +712,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.67",
+ "syn 2.0.68",
  "which",
 ]
 
@@ -754,9 +755,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -814,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cexpr"
@@ -1468,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -2024,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -2042,9 +2043,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.5",
@@ -2074,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -2137,7 +2138,7 @@ dependencies = [
  "cosmwasm-std",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "protobuf 3.4.0",
+ "protobuf 3.5.0",
  "schemars",
  "serde",
  "serde-json-wasm 1.0.1",
@@ -2212,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -2345,7 +2346,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2389,7 +2390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2403,13 +2404,13 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -2464,7 +2465,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2496,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58678a64de2fced2bdec6bca052a6716a0efe692d6e3f53d1bda6a1def64cfc0"
+checksum = "df67496db1a89596beaced1579212e9b7c53c22dca1d9745de00ead76573d514"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -2507,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ed294a835b0f30810e13616b1cd34943c6d1e84a8f3b0dcfe466d256c3e7e7"
+checksum = "70e2d30ab1878b2e72d1e2fc23ff5517799c9929e2cf81a8516f9f4dcf2b9cf3"
 dependencies = [
  "thiserror",
 ]
@@ -2668,7 +2669,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2808,7 +2809,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2921,7 +2922,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2960,7 +2961,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3021,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -3036,7 +3037,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3047,14 +3048,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -3069,7 +3070,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3235,14 +3236,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subtle-encoding"
@@ -3272,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.67"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3458,7 +3459,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3469,7 +3470,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
  "test-case-core",
 ]
 
@@ -3504,7 +3505,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3548,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3586,7 +3587,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3734,9 +3735,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 
 [[package]]
 name = "version_check"
@@ -3799,7 +3800,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -3833,7 +3834,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4063,5 +4064,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.68",
 ]

--- a/contracts/pair_transmuter/Cargo.toml
+++ b/contracts/pair_transmuter/Cargo.toml
@@ -32,5 +32,5 @@ anyhow = "1"
 derivative = "2"
 cw20-base = "1.1"
 astroport-factory = { path = "../factory" }
-astroport-native-coin-registry = { path = "../periphery/native_coin_registry", version = "1" }
+astroport-native-coin-registry = { path = "../periphery/native_coin_registry" }
 astroport-test = { path = "../../packages/astroport_test" }

--- a/contracts/periphery/native_coin_registry/Cargo.toml
+++ b/contracts/periphery/native_coin_registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-native-coin-registry"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "Astroport Native Coin Registry serves as a simple on-chain registry for native coin precisions which must be governed by trustfull parties like DAO."
@@ -28,10 +28,11 @@ library = []
 [dependencies]
 cosmwasm-schema.workspace = true
 cosmwasm-std.workspace = true
-cw-storage-plus = "0.15"
+cw-storage-plus.workspace = true
 cw2.workspace = true
 thiserror.workspace = true
-astroport = "3"
+itertools.workspace = true
+astroport = { path = "../../../packages/astroport", version = "5.2" }
 
 [dev-dependencies]
 cw-multi-test = "1.0.0"

--- a/contracts/periphery/native_coin_registry/examples/native_coin_registry_schema.rs
+++ b/contracts/periphery/native_coin_registry/examples/native_coin_registry_schema.rs
@@ -1,4 +1,4 @@
-use astroport::native_coin_registry::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use astroport::native_coin_registry::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use cosmwasm_schema::write_api;
 
 fn main() {
@@ -6,6 +6,5 @@ fn main() {
         instantiate: InstantiateMsg,
         execute: ExecuteMsg,
         query: QueryMsg,
-        migrate: MigrateMsg
     }
 }

--- a/contracts/periphery/native_coin_registry/src/error.rs
+++ b/contracts/periphery/native_coin_registry/src/error.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::StdError;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
@@ -15,9 +15,15 @@ pub enum ContractError {
     #[error("Duplicate coins are provided")]
     DuplicateCoins {},
 
-    #[error("The coin cannot have zero precision: {0}")]
-    CoinWithZeroPrecision(String),
+    #[error("Invalid decimals {decimals} for {denom}. Allowed: 0-18")]
+    InvalidDecimals { denom: String, decimals: u8 },
 
     #[error("The coin does not exist: {0}")]
     CoinDoesNotExist(String),
+
+    #[error("The coin already exists: {0}")]
+    CoinAlreadyExists(String),
+
+    #[error("You must send 1 {0} unit")]
+    MustSendCoin(String),
 }

--- a/contracts/periphery/native_coin_registry/src/lib.rs
+++ b/contracts/periphery/native_coin_registry/src/lib.rs
@@ -1,5 +1,3 @@
 pub mod contract;
-mod error;
+pub mod error;
 pub mod state;
-
-pub use crate::error::ContractError;

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport"
-version = "5.1.0"
+version = "5.2.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "Common Astroport types, queriers and other utils"

--- a/packages/astroport/src/native_coin_registry.rs
+++ b/packages/astroport/src/native_coin_registry.rs
@@ -19,16 +19,19 @@ pub struct InstantiateMsg {
 /// This structure describes the execute messages available in the contract.
 #[cw_serde]
 pub enum ExecuteMsg {
-    /// Adds or updates native assets with specified precisions
-    /// ## Executor
-    /// Only the current owner can execute this
+    /// Adds or updates native assets with specified precisions.
+    /// Only the current owner can execute this.
+    /// Sender doesn't need to send any tokens.
     Add { native_coins: Vec<(String, u8)> },
+    /// Register a native asset in the registry.
+    /// Sender must send any number of coins per each asset added.
+    /// All funds will be returned to the sender.
+    /// Permissionless
+    Register { native_coins: Vec<(String, u8)> },
     /// Removes the native assets by specified parameters
-    /// ## Executor
     /// Only the current owner can execute this
     Remove { native_coins: Vec<String> },
     /// Creates a request to change contract ownership
-    /// ## Executor
     /// Only the current owner can execute this
     ProposeNewOwner {
         /// The newly proposed owner
@@ -37,11 +40,9 @@ pub enum ExecuteMsg {
         expires_in: u64,
     },
     /// Removes a request to change contract ownership
-    /// ## Executor
     /// Only the current owner can execute this
     DropOwnershipProposal {},
     /// Claims contract ownership
-    /// ## Executor
     /// Only the newly proposed owner can execute this
     ClaimOwnership {},
 }
@@ -71,11 +72,6 @@ pub struct CoinResponse {
     /// The asset precision
     pub decimals: u8,
 }
-
-/// This structure describes a migration message.
-/// We currently take no arguments for migrations.
-#[cw_serde]
-pub struct MigrateMsg {}
 
 /// The first key is denom, the second key is a precision.
 pub const COINS_INFO: Map<String, u8> = Map::new("coins_info");

--- a/schemas/astroport-native-coin-registry/astroport-native-coin-registry.json
+++ b/schemas/astroport-native-coin-registry/astroport-native-coin-registry.json
@@ -1,0 +1,340 @@
+{
+  "contract_name": "astroport-native-coin-registry",
+  "contract_version": "1.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "description": "This structure describes the parameters used for creating a contract.",
+    "type": "object",
+    "required": [
+      "owner"
+    ],
+    "properties": {
+      "owner": {
+        "description": "Address allowed to change contract parameters",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "description": "This structure describes the execute messages available in the contract.",
+    "oneOf": [
+      {
+        "description": "Adds or updates native assets with specified precisions. Only the current owner can execute this. Sender doesn't need to send any tokens.",
+        "type": "object",
+        "required": [
+          "add"
+        ],
+        "properties": {
+          "add": {
+            "type": "object",
+            "required": [
+              "native_coins"
+            ],
+            "properties": {
+              "native_coins": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer",
+                      "format": "uint8",
+                      "minimum": 0.0
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Register a native asset in the registry. Sender must send any number of coins per each asset added. All funds will be returned to the sender. Permissionless",
+        "type": "object",
+        "required": [
+          "register"
+        ],
+        "properties": {
+          "register": {
+            "type": "object",
+            "required": [
+              "native_coins"
+            ],
+            "properties": {
+              "native_coins": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer",
+                      "format": "uint8",
+                      "minimum": 0.0
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the native assets by specified parameters Only the current owner can execute this",
+        "type": "object",
+        "required": [
+          "remove"
+        ],
+        "properties": {
+          "remove": {
+            "type": "object",
+            "required": [
+              "native_coins"
+            ],
+            "properties": {
+              "native_coins": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Creates a request to change contract ownership Only the current owner can execute this",
+        "type": "object",
+        "required": [
+          "propose_new_owner"
+        ],
+        "properties": {
+          "propose_new_owner": {
+            "type": "object",
+            "required": [
+              "expires_in",
+              "owner"
+            ],
+            "properties": {
+              "expires_in": {
+                "description": "The validity period of the offer to change the owner",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "owner": {
+                "description": "The newly proposed owner",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes a request to change contract ownership Only the current owner can execute this",
+        "type": "object",
+        "required": [
+          "drop_ownership_proposal"
+        ],
+        "properties": {
+          "drop_ownership_proposal": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Claims contract ownership Only the newly proposed owner can execute this",
+        "type": "object",
+        "required": [
+          "claim_ownership"
+        ],
+        "properties": {
+          "claim_ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "This structure describes the query messages available in the contract.",
+    "oneOf": [
+      {
+        "description": "Returns the configuration for the contract.",
+        "type": "object",
+        "required": [
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the information about Asset by specified denominator.",
+        "type": "object",
+        "required": [
+          "native_token"
+        ],
+        "properties": {
+          "native_token": {
+            "type": "object",
+            "required": [
+              "denom"
+            ],
+            "properties": {
+              "denom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns a vector which contains the native assets.",
+        "type": "object",
+        "required": [
+          "native_tokens"
+        ],
+        "properties": {
+          "native_tokens": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "description": "This structure stores the main parameters for the native coin registry contract.",
+      "type": "object",
+      "required": [
+        "owner"
+      ],
+      "properties": {
+        "owner": {
+          "description": "Address that's allowed to change contract parameters",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        }
+      }
+    },
+    "native_token": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "CoinResponse",
+      "type": "object",
+      "required": [
+        "decimals",
+        "denom"
+      ],
+      "properties": {
+        "decimals": {
+          "description": "The asset precision",
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "denom": {
+          "description": "The asset name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "native_tokens": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_CoinResponse",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/CoinResponse"
+      },
+      "definitions": {
+        "CoinResponse": {
+          "type": "object",
+          "required": [
+            "decimals",
+            "denom"
+          ],
+          "properties": {
+            "decimals": {
+              "description": "The asset precision",
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            },
+            "denom": {
+              "description": "The asset name",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}

--- a/schemas/astroport-native-coin-registry/raw/execute.json
+++ b/schemas/astroport-native-coin-registry/raw/execute.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "description": "This structure describes the execute messages available in the contract.",
+  "oneOf": [
+    {
+      "description": "Adds or updates native assets with specified precisions. Only the current owner can execute this. Sender doesn't need to send any tokens.",
+      "type": "object",
+      "required": [
+        "add"
+      ],
+      "properties": {
+        "add": {
+          "type": "object",
+          "required": [
+            "native_coins"
+          ],
+          "properties": {
+            "native_coins": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Register a native asset in the registry. Sender must send any number of coins per each asset added. All funds will be returned to the sender. Permissionless",
+      "type": "object",
+      "required": [
+        "register"
+      ],
+      "properties": {
+        "register": {
+          "type": "object",
+          "required": [
+            "native_coins"
+          ],
+          "properties": {
+            "native_coins": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Removes the native assets by specified parameters Only the current owner can execute this",
+      "type": "object",
+      "required": [
+        "remove"
+      ],
+      "properties": {
+        "remove": {
+          "type": "object",
+          "required": [
+            "native_coins"
+          ],
+          "properties": {
+            "native_coins": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Creates a request to change contract ownership Only the current owner can execute this",
+      "type": "object",
+      "required": [
+        "propose_new_owner"
+      ],
+      "properties": {
+        "propose_new_owner": {
+          "type": "object",
+          "required": [
+            "expires_in",
+            "owner"
+          ],
+          "properties": {
+            "expires_in": {
+              "description": "The validity period of the offer to change the owner",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "owner": {
+              "description": "The newly proposed owner",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Removes a request to change contract ownership Only the current owner can execute this",
+      "type": "object",
+      "required": [
+        "drop_ownership_proposal"
+      ],
+      "properties": {
+        "drop_ownership_proposal": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Claims contract ownership Only the newly proposed owner can execute this",
+      "type": "object",
+      "required": [
+        "claim_ownership"
+      ],
+      "properties": {
+        "claim_ownership": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/schemas/astroport-native-coin-registry/raw/instantiate.json
+++ b/schemas/astroport-native-coin-registry/raw/instantiate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "description": "This structure describes the parameters used for creating a contract.",
+  "type": "object",
+  "required": [
+    "owner"
+  ],
+  "properties": {
+    "owner": {
+      "description": "Address allowed to change contract parameters",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/astroport-native-coin-registry/raw/query.json
+++ b/schemas/astroport-native-coin-registry/raw/query.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "description": "This structure describes the query messages available in the contract.",
+  "oneOf": [
+    {
+      "description": "Returns the configuration for the contract.",
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Returns the information about Asset by specified denominator.",
+      "type": "object",
+      "required": [
+        "native_token"
+      ],
+      "properties": {
+        "native_token": {
+          "type": "object",
+          "required": [
+            "denom"
+          ],
+          "properties": {
+            "denom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Returns a vector which contains the native assets.",
+      "type": "object",
+      "required": [
+        "native_tokens"
+      ],
+      "properties": {
+        "native_tokens": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/schemas/astroport-native-coin-registry/raw/response_to_config.json
+++ b/schemas/astroport-native-coin-registry/raw/response_to_config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Config",
+  "description": "This structure stores the main parameters for the native coin registry contract.",
+  "type": "object",
+  "required": [
+    "owner"
+  ],
+  "properties": {
+    "owner": {
+      "description": "Address that's allowed to change contract parameters",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Addr"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    }
+  }
+}

--- a/schemas/astroport-native-coin-registry/raw/response_to_native_token.json
+++ b/schemas/astroport-native-coin-registry/raw/response_to_native_token.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CoinResponse",
+  "type": "object",
+  "required": [
+    "decimals",
+    "denom"
+  ],
+  "properties": {
+    "decimals": {
+      "description": "The asset precision",
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "denom": {
+      "description": "The asset name",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/astroport-native-coin-registry/raw/response_to_native_tokens.json
+++ b/schemas/astroport-native-coin-registry/raw/response_to_native_tokens.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Array_of_CoinResponse",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/CoinResponse"
+  },
+  "definitions": {
+    "CoinResponse": {
+      "type": "object",
+      "required": [
+        "decimals",
+        "denom"
+      ],
+      "properties": {
+        "decimals": {
+          "description": "The asset precision",
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "denom": {
+          "description": "The asset name",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,4 +1,4 @@
-#!/usr/src/env bash
+#!/usr/bin/env bash
 
 # Usage: ./scripts/coverage.sh <package_name>
 # Example: ./scripts/coverage.sh astroport-pair


### PR DESCRIPTION
This is non-breaking change thus `astroport-native-coin-registry` contract version is bumped to v1.1.0.

* added new permissionless endpoint `register { native_coins: [...] }` which allows to set decimals for denom if it hasn't registered yet. Sender must send any number of coin per denom. All funds are sent back to sender after message is executed.
* both permissioned (`add`) and permissionless (`register`) endpoints allow to set decimals only from range 0-18.