### PR TITLE
feat(staking): add ability to call hook contract on stake action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "5.3.0"
+version = "5.4.0"
 dependencies = [
  "astroport-circular-buffer 0.2.0",
  "cosmos-sdk-proto 0.19.0",
@@ -196,7 +196,7 @@ name = "astroport-factory"
 version = "1.8.1"
 dependencies = [
  "anyhow",
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "astroport-pair 2.0.2",
  "astroport-test",
  "cosmwasm-schema",
@@ -245,7 +245,7 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "astro-token-converter",
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-pair 2.0.2",
@@ -341,7 +341,7 @@ dependencies = [
 name = "astroport-pair"
 version = "2.0.2"
 dependencies = [
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "astroport-factory",
  "astroport-incentives",
  "astroport-test",
@@ -364,7 +364,7 @@ name = "astroport-pair-concentrated"
 version = "4.0.2"
 dependencies = [
  "anyhow",
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "astroport-circular-buffer 0.2.0",
  "astroport-factory",
  "astroport-incentives",
@@ -413,7 +413,7 @@ name = "astroport-pair-stable"
 version = "4.0.1"
 dependencies = [
  "anyhow",
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "astroport-circular-buffer 0.2.0",
  "astroport-factory",
  "astroport-incentives",
@@ -439,7 +439,7 @@ name = "astroport-pair-transmuter"
 version = "1.1.2"
 dependencies = [
  "anyhow",
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "astroport-factory",
  "astroport-native-coin-registry",
  "astroport-test",
@@ -459,7 +459,7 @@ dependencies = [
 name = "astroport-pair-xyk-sale-tax"
 version = "2.0.2"
 dependencies = [
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "astroport-factory",
  "astroport-incentives",
  "astroport-pair 1.3.3",
@@ -485,7 +485,7 @@ name = "astroport-pcl-common"
 version = "2.0.2"
 dependencies = [
  "anyhow",
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "astroport-factory",
  "astroport-test",
  "cosmwasm-schema",
@@ -517,10 +517,11 @@ dependencies = [
 
 [[package]]
 name = "astroport-staking"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "astroport 4.0.3",
+ "astroport 5.4.0",
  "astroport-tokenfactory-tracker 1.0.0",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -538,7 +539,7 @@ name = "astroport-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "astroport 5.3.0",
+ "astroport 5.4.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ thiserror = "1.0"
 itertools = "0.12"
 cosmwasm-schema = "1.5"
 cw-utils = "1"
-astroport = { path = "./packages/astroport", version = "5.3.0" }
+astroport = { path = "./packages/astroport", version = "5.4.0" }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/tokenomics/staking/Cargo.toml
+++ b/contracts/tokenomics/staking/Cargo.toml
@@ -38,4 +38,4 @@ anyhow = "1"
 itertools.workspace = true
 cosmwasm-schema.workspace = true
 cw-multi-test = { git = "https://github.com/astroport-fi/cw-multi-test", branch = "feat/bank_with_send_hooks", features = ["cosmwasm_1_1"] }
-astroport-tokenfactory-tracker = "1"
+astroport-tokenfactory-tracker = "1.0.0"

--- a/contracts/tokenomics/staking/Cargo.toml
+++ b/contracts/tokenomics/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-staking"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "Astroport Staking Contract"
@@ -28,7 +28,8 @@ cosmwasm-std = { workspace = true, features = ["cosmwasm_1_1"] }
 cw-storage-plus.workspace = true
 thiserror.workspace = true
 cw2.workspace = true
-astroport = "4"
+astroport.workspace = true
+astroport_v4 = { package = "astroport", version = "4" }
 cw-utils.workspace = true
 osmosis-std = "0.21.0"
 
@@ -37,4 +38,4 @@ anyhow = "1"
 itertools.workspace = true
 cosmwasm-schema.workspace = true
 cw-multi-test = { git = "https://github.com/astroport-fi/cw-multi-test", branch = "feat/bank_with_send_hooks", features = ["cosmwasm_1_1"] }
-astroport-tokenfactory-tracker = "1.0.0"
+astroport-tokenfactory-tracker = "1"

--- a/contracts/tokenomics/staking/src/contract.rs
+++ b/contracts/tokenomics/staking/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, coin, ensure, to_json_binary, BankMsg, Binary, CosmosMsg, Deps, DepsMut, Env,
+    attr, coin, ensure, to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env,
     MessageInfo, Reply, Response, StdError, StdResult, SubMsg, Uint128, WasmMsg,
 };
 use cw2::set_contract_version;
@@ -13,7 +13,7 @@ use osmosis_std::types::osmosis::tokenfactory::v1beta1::{
 };
 
 use astroport::staking::{
-    Config, ExecuteMsg, InstantiateMsg, QueryMsg, StakingResponse, TrackerData,
+    Config, ExecuteMsg, InstantiateMsg, QueryMsg, StakingResponse, TrackerData, HOOK_GAS_LIMIT,
 };
 
 use crate::error::ContractError;
@@ -115,7 +115,34 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::Enter { receiver } => execute_enter(deps, env, info, receiver),
+        ExecuteMsg::Enter { receiver } => {
+            // xASTRO is minted to the receiver if provided or to the sender.
+            let recipient = receiver.unwrap_or_else(|| info.sender.to_string());
+            execute_enter(deps, env, info).map(|(resp, minted_coins)| {
+                resp.add_message(BankMsg::Send {
+                    to_address: recipient.clone(),
+                    amount: vec![minted_coins],
+                })
+                .add_attributes([("action", "enter"), ("recipient", recipient.as_str())])
+            })
+        }
+        ExecuteMsg::EnterWithHook {
+            contract_address,
+            msg,
+        } => execute_enter(deps, env, info).map(|(resp, minted_coins)| {
+            resp.add_submessage(
+                SubMsg::new(WasmMsg::Execute {
+                    contract_addr: contract_address.clone(),
+                    msg,
+                    funds: vec![minted_coins],
+                })
+                .with_gas_limit(HOOK_GAS_LIMIT),
+            )
+            .add_attributes([
+                ("action", "enter_with_hook"),
+                ("next_contract", &contract_address),
+            ])
+        }),
         ExecuteMsg::Leave {} => execute_leave(deps, env, info),
     }
 }
@@ -163,7 +190,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                 WasmMsg::Instantiate {
                     admin: Some(tracker_data.admin),
                     code_id: tracker_data.code_id,
-                    msg: to_json_binary(&astroport::tokenfactory_tracker::InstantiateMsg {
+                    msg: to_json_binary(&astroport_v4::tokenfactory_tracker::InstantiateMsg {
                         tokenfactory_module_address: tracker_data.token_factory_addr,
                         tracked_denom: new_token_denom.clone(),
                     })?,
@@ -204,13 +231,14 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
 }
 
 /// Enter stakes TokenFactory ASTRO for xASTRO.
-/// xASTRO is minted to the receiver if provided or to the sender.
+/// Returns composed Response object and minted xASTRO in the form of [`Coin`].
+/// Subsequent messages are added after,
+/// depending on whether it is a plain enter or enter with hook endpoint.
 fn execute_enter(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    receiver: Option<String>,
-) -> Result<Response, ContractError> {
+) -> Result<(Response, Coin), ContractError> {
     let config = CONFIG.load(deps.storage)?;
 
     // Ensure that the correct denom is sent. Sending zero tokens is prohibited on chain level
@@ -255,24 +283,12 @@ fn execute_enter(
 
     let minted_coins = coin(mint_amount.u128(), config.xastro_denom);
 
-    // Mint new xASTRO tokens to the sender
+    // Mint new xASTRO tokens to the staking contract
     messages.push(
         MsgMint {
             sender: env.contract.address.to_string(),
             amount: Some(minted_coins.clone().into()),
             mint_to_address: env.contract.address.to_string(),
-        }
-        .into(),
-    );
-
-    let recipient = receiver.unwrap_or_else(|| info.sender.to_string());
-
-    // TokenFactory minting only allows minting to the sender for now, thus we
-    // need to send the minted tokens to the recipient
-    messages.push(
-        BankMsg::Send {
-            to_address: recipient.clone(),
-            amount: vec![minted_coins],
         }
         .into(),
     );
@@ -284,15 +300,16 @@ fn execute_enter(
         xastro_amount: mint_amount,
     })?;
 
-    Ok(Response::new()
-        .add_messages(messages)
-        .set_data(staking_response)
-        .add_attributes([
-            attr("action", "enter"),
-            attr("recipient", recipient),
-            attr("astro_amount", amount),
-            attr("xastro_amount", mint_amount),
-        ]))
+    Ok((
+        Response::new()
+            .add_messages(messages)
+            .set_data(staking_response)
+            .add_attributes([
+                attr("astro_amount", amount),
+                attr("xastro_amount", mint_amount),
+            ]),
+        minted_coins,
+    ))
 }
 
 /// Leave unstakes TokenFactory xASTRO for ASTRO. xASTRO is burned and ASTRO
@@ -397,7 +414,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 let tracker_config = TRACKER_DATA.load(deps.storage)?;
                 deps.querier.query_wasm_smart(
                     tracker_config.tracker_addr,
-                    &astroport::tokenfactory_tracker::QueryMsg::BalanceAt { address, timestamp },
+                    &astroport_v4::tokenfactory_tracker::QueryMsg::BalanceAt { address, timestamp },
                 )?
             };
 
@@ -411,7 +428,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 let tracker_config = TRACKER_DATA.load(deps.storage)?;
                 deps.querier.query_wasm_smart(
                     tracker_config.tracker_addr,
-                    &astroport::tokenfactory_tracker::QueryMsg::TotalSupplyAt { timestamp },
+                    &astroport_v4::tokenfactory_tracker::QueryMsg::TotalSupplyAt { timestamp },
                 )?
             };
 

--- a/contracts/tokenomics/staking/src/contract.rs
+++ b/contracts/tokenomics/staking/src/contract.rs
@@ -13,7 +13,7 @@ use osmosis_std::types::osmosis::tokenfactory::v1beta1::{
 };
 
 use astroport::staking::{
-    Config, ExecuteMsg, InstantiateMsg, QueryMsg, StakingResponse, TrackerData, HOOK_GAS_LIMIT,
+    Config, ExecuteMsg, InstantiateMsg, QueryMsg, StakingResponse, TrackerData,
 };
 
 use crate::error::ContractError;
@@ -130,14 +130,11 @@ pub fn execute(
             contract_address,
             msg,
         } => execute_enter(deps, env, info).map(|(resp, minted_coins)| {
-            resp.add_submessage(
-                SubMsg::new(WasmMsg::Execute {
-                    contract_addr: contract_address.clone(),
-                    msg,
-                    funds: vec![minted_coins],
-                })
-                .with_gas_limit(HOOK_GAS_LIMIT),
-            )
+            resp.add_message(WasmMsg::Execute {
+                contract_addr: contract_address.clone(),
+                msg,
+                funds: vec![minted_coins],
+            })
             .add_attributes([
                 ("action", "enter_with_hook"),
                 ("next_contract", &contract_address),

--- a/contracts/tokenomics/staking/src/migrate.rs
+++ b/contracts/tokenomics/staking/src/migrate.rs
@@ -14,7 +14,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
     match contract_version.contract.as_ref() {
         "astroport-staking" => match contract_version.version.as_ref() {
-            "2.0.0" => {}
+            "2.0.0" | "2.1.0" => {}
             _ => return Err(ContractError::MigrationError {}),
         },
         _ => return Err(ContractError::MigrationError {}),

--- a/contracts/tokenomics/staking/tests/common/helper.rs
+++ b/contracts/tokenomics/staking/tests/common/helper.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 
 use anyhow::Result as AnyResult;
+use cosmwasm_schema::serde::Serialize;
 use cosmwasm_std::testing::MockApi;
 use cosmwasm_std::{
-    coins, Addr, Coin, DepsMut, Empty, Env, GovMsg, IbcMsg, IbcQuery, MemoryStorage, MessageInfo,
-    Response, StdResult, Uint128,
+    coins, to_json_binary, Addr, Coin, DepsMut, Empty, Env, GovMsg, IbcMsg, IbcQuery,
+    MemoryStorage, MessageInfo, Response, StdResult, Uint128,
 };
 use cw_multi_test::{
     App, AppResponse, BankKeeper, BasicAppBuilder, Contract, ContractWrapper, DistributionKeeper,
@@ -126,6 +127,24 @@ impl Helper {
             sender.clone(),
             self.staking.clone(),
             &ExecuteMsg::Enter { receiver: None },
+            &coins(amount, ASTRO_DENOM),
+        )
+    }
+
+    pub fn stake_with_hook<T: Serialize + ?Sized>(
+        &mut self,
+        sender: &Addr,
+        amount: u128,
+        contract_address: String,
+        msg: &T,
+    ) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            sender.clone(),
+            self.staking.clone(),
+            &ExecuteMsg::EnterWithHook {
+                contract_address,
+                msg: to_json_binary(msg)?,
+            },
             &coins(amount, ASTRO_DENOM),
         )
     }

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport"
-version = "5.3.0"
+version = "5.4.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "Common Astroport types, queriers and other utils"

--- a/packages/astroport/src/staking.rs
+++ b/packages/astroport/src/staking.rs
@@ -1,5 +1,8 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Binary, Uint128};
+
+/// Enforces gas limit for contracts used in ExecuteMsg::EnterWithHook.
+pub const HOOK_GAS_LIMIT: u64 = 1_000_000;
 
 /// This structure describes the parameters used for creating a contract.
 #[cw_serde]
@@ -8,7 +11,7 @@ pub struct InstantiateMsg {
     pub deposit_token_denom: String,
     /// Tracking contract admin
     pub tracking_admin: String,
-    // The Code ID of contract used to track the TokenFactory token balances
+    /// The Code ID of contract used to track the TokenFactory token balances
     pub tracking_code_id: u64,
     /// Token factory module address. Contract creator must ensure that the address is exact token factory module address.
     pub token_factory_addr: String,
@@ -20,6 +23,13 @@ pub enum ExecuteMsg {
     /// Deposits ASTRO in exchange for xASTRO
     /// The receiver is optional. If not set, the sender will receive the xASTRO.
     Enter { receiver: Option<String> },
+    /// Deposits ASTRO in exchange for xASTRO
+    /// and passes **all resulting xASTRO** to defined contract along with an executable message.
+    /// Note that the next message will be executed with limited gas (see HOOK_GAS_LIMIT).
+    EnterWithHook {
+        contract_address: String,
+        msg: Binary,
+    },
     /// Burns xASTRO in exchange for ASTRO
     Leave {},
 }
@@ -74,7 +84,7 @@ pub struct TrackerData {
     pub tracker_addr: String,
 }
 
-// The structure returned as part of set_data when staking or unstaking
+/// The structure returned as part of set_data when staking or unstaking
 #[cw_serde]
 pub struct StakingResponse {
     /// The ASTRO denom

--- a/packages/astroport/src/staking.rs
+++ b/packages/astroport/src/staking.rs
@@ -1,9 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Binary, Uint128};
 
-/// Enforces gas limit for contracts used in ExecuteMsg::EnterWithHook.
-pub const HOOK_GAS_LIMIT: u64 = 1_000_000;
-
 /// This structure describes the parameters used for creating a contract.
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -25,7 +22,6 @@ pub enum ExecuteMsg {
     Enter { receiver: Option<String> },
     /// Deposits ASTRO in exchange for xASTRO
     /// and passes **all resulting xASTRO** to defined contract along with an executable message.
-    /// Note that the next message will be executed with limited gas (see HOOK_GAS_LIMIT).
     EnterWithHook {
         contract_address: String,
         msg: Binary,

--- a/schemas/astroport-staking/astroport-staking.json
+++ b/schemas/astroport-staking/astroport-staking.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "astroport-staking",
-  "contract_version": "2.1.0",
+  "contract_version": "2.2.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -27,6 +27,7 @@
         "type": "string"
       },
       "tracking_code_id": {
+        "description": "The Code ID of contract used to track the TokenFactory token balances",
         "type": "integer",
         "format": "uint64",
         "minimum": 0.0
@@ -62,6 +63,32 @@
         "additionalProperties": false
       },
       {
+        "description": "Deposits ASTRO in exchange for xASTRO and passes **all resulting xASTRO** to defined contract along with an executable message.",
+        "type": "object",
+        "required": [
+          "enter_with_hook"
+        ],
+        "properties": {
+          "enter_with_hook": {
+            "type": "object",
+            "required": [
+              "contract_address",
+              "msg"
+            ],
+            "properties": {
+              "contract_address": {
+                "type": "string"
+              },
+              "msg": {
+                "$ref": "#/definitions/Binary"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Burns xASTRO in exchange for ASTRO",
         "type": "object",
         "required": [
@@ -75,7 +102,13 @@
         },
         "additionalProperties": false
       }
-    ]
+    ],
+    "definitions": {
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      }
+    }
   },
   "query": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/astroport-staking/raw/execute.json
+++ b/schemas/astroport-staking/raw/execute.json
@@ -26,6 +26,32 @@
       "additionalProperties": false
     },
     {
+      "description": "Deposits ASTRO in exchange for xASTRO and passes **all resulting xASTRO** to defined contract along with an executable message.",
+      "type": "object",
+      "required": [
+        "enter_with_hook"
+      ],
+      "properties": {
+        "enter_with_hook": {
+          "type": "object",
+          "required": [
+            "contract_address",
+            "msg"
+          ],
+          "properties": {
+            "contract_address": {
+              "type": "string"
+            },
+            "msg": {
+              "$ref": "#/definitions/Binary"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Burns xASTRO in exchange for ASTRO",
       "type": "object",
       "required": [
@@ -39,5 +65,11 @@
       },
       "additionalProperties": false
     }
-  ]
+  ],
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    }
+  }
 }

--- a/schemas/astroport-staking/raw/instantiate.json
+++ b/schemas/astroport-staking/raw/instantiate.json
@@ -23,6 +23,7 @@
       "type": "string"
     },
     "tracking_code_id": {
+      "description": "The Code ID of contract used to track the TokenFactory token balances",
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0


### PR DESCRIPTION
Adding new endpoint `EnterWithHook { contract_address: Addr, msg: Binary }` which allows to stake ASTRO and immediately pass all resulting xASTRO to the hook contract.