### PR TITLE
feat(pairs): pass pair type from factory during pool instantiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,11 +193,27 @@ dependencies = [
 
 [[package]]
 name = "astroport-factory"
-version = "1.8.1"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68abcc896255acba2f4aa39f239a1e8361a6035d7bc712442da122dc31f6f959"
+dependencies = [
+ "astroport 5.2.0",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
+ "itertools 0.12.1",
+ "thiserror",
+]
+
+[[package]]
+name = "astroport-factory"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "astroport 5.4.0",
- "astroport-pair 2.0.2",
+ "astroport-pair 2.1.0",
  "astroport-test",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -246,9 +262,9 @@ dependencies = [
  "anyhow",
  "astro-token-converter",
  "astroport 5.4.0",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-native-coin-registry",
- "astroport-pair 2.0.2",
+ "astroport-pair 2.1.0",
  "astroport-pair-stable",
  "astroport-test",
  "astroport-vesting 1.3.1",
@@ -271,9 +287,9 @@ version = "1.5.0"
 dependencies = [
  "astro-satellite-package",
  "astroport 4.0.3",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-native-coin-registry",
- "astroport-pair 2.0.2",
+ "astroport-pair 2.1.0",
  "astroport-pair-stable",
  "astroport-test",
  "cosmwasm-schema",
@@ -305,9 +321,9 @@ version = "2.1.2"
 dependencies = [
  "anyhow",
  "astroport 3.12.2",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-native-coin-registry",
- "astroport-pair 2.0.2",
+ "astroport-pair 2.1.0",
  "astroport-pair-stable",
  "astroport-test",
  "cosmwasm-schema",
@@ -339,10 +355,10 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "astroport 5.4.0",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-incentives",
  "astroport-test",
  "astroport-tokenfactory-tracker 2.0.0",
@@ -361,12 +377,12 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-concentrated"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "astroport 5.4.0",
  "astroport-circular-buffer 0.2.0",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-incentives",
  "astroport-native-coin-registry",
  "astroport-pcl-common",
@@ -392,7 +408,7 @@ dependencies = [
  "anyhow",
  "astro-token-converter",
  "astroport 4.0.3",
- "astroport-factory",
+ "astroport-factory 1.8.0",
  "astroport-pair 1.3.3",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -410,12 +426,12 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-stable"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "astroport 5.4.0",
  "astroport-circular-buffer 0.2.0",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-incentives",
  "astroport-native-coin-registry",
  "astroport-test",
@@ -440,7 +456,7 @@ version = "1.1.2"
 dependencies = [
  "anyhow",
  "astroport 5.4.0",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-native-coin-registry",
  "astroport-test",
  "cosmwasm-schema",
@@ -457,13 +473,13 @@ dependencies = [
 
 [[package]]
 name = "astroport-pair-xyk-sale-tax"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "astroport 5.4.0",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-incentives",
  "astroport-pair 1.3.3",
- "astroport-pair 2.0.2",
+ "astroport-pair 2.1.0",
  "astroport-test",
  "astroport-tokenfactory-tracker 2.0.0",
  "cosmwasm-schema",
@@ -486,7 +502,7 @@ version = "2.0.2"
 dependencies = [
  "anyhow",
  "astroport 5.4.0",
- "astroport-factory",
+ "astroport-factory 1.9.0",
  "astroport-test",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -502,8 +518,8 @@ version = "1.2.1"
 dependencies = [
  "anyhow",
  "astroport 3.12.2",
- "astroport-factory",
- "astroport-pair 2.0.2",
+ "astroport-factory 1.9.0",
+ "astroport-pair 2.1.0",
  "astroport-test",
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "5.4.0"
+version = "5.5.0"
 dependencies = [
  "astroport-circular-buffer 0.2.0",
  "cosmos-sdk-proto 0.19.0",
@@ -212,7 +212,7 @@ name = "astroport-factory"
 version = "1.9.0"
 dependencies = [
  "anyhow",
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-pair 2.1.0",
  "astroport-test",
  "cosmwasm-schema",
@@ -261,7 +261,7 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "astro-token-converter",
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-factory 1.9.0",
  "astroport-native-coin-registry",
  "astroport-pair 2.1.0",
@@ -357,7 +357,7 @@ dependencies = [
 name = "astroport-pair"
 version = "2.1.0"
 dependencies = [
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-factory 1.9.0",
  "astroport-incentives",
  "astroport-test",
@@ -380,7 +380,7 @@ name = "astroport-pair-concentrated"
 version = "4.1.0"
 dependencies = [
  "anyhow",
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-circular-buffer 0.2.0",
  "astroport-factory 1.9.0",
  "astroport-incentives",
@@ -429,7 +429,7 @@ name = "astroport-pair-stable"
 version = "4.1.0"
 dependencies = [
  "anyhow",
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-circular-buffer 0.2.0",
  "astroport-factory 1.9.0",
  "astroport-incentives",
@@ -455,7 +455,7 @@ name = "astroport-pair-transmuter"
 version = "1.1.2"
 dependencies = [
  "anyhow",
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-factory 1.9.0",
  "astroport-native-coin-registry",
  "astroport-test",
@@ -475,7 +475,7 @@ dependencies = [
 name = "astroport-pair-xyk-sale-tax"
 version = "2.1.0"
 dependencies = [
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-factory 1.9.0",
  "astroport-incentives",
  "astroport-pair 1.3.3",
@@ -501,7 +501,7 @@ name = "astroport-pcl-common"
 version = "2.0.2"
 dependencies = [
  "anyhow",
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-factory 1.9.0",
  "astroport-test",
  "cosmwasm-schema",
@@ -537,7 +537,7 @@ version = "2.2.0"
 dependencies = [
  "anyhow",
  "astroport 4.0.3",
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "astroport-tokenfactory-tracker 1.0.0",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -555,7 +555,7 @@ name = "astroport-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "astroport 5.4.0",
+ "astroport 5.5.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 1.0.0",

--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-factory"
-version = "1.8.1"
+version = "1.9.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "Astroport factory contract - pair contract generator and directory"

--- a/contracts/factory/src/testing.rs
+++ b/contracts/factory/src/testing.rs
@@ -498,6 +498,7 @@ fn create_pair() {
         vec![SubMsg {
             msg: WasmMsg::Instantiate {
                 msg: to_json_binary(&PairInstantiateMsg {
+                    pair_type: PairType::Xyk {},
                     factory_addr: String::from(MOCK_CONTRACT_ADDR),
                     asset_infos: asset_infos.clone(),
                     token_code_id: msg.token_code_id,

--- a/contracts/pair/Cargo.toml
+++ b/contracts/pair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair"
-version = "2.0.2"
+version = "2.1.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport constant product pool contract implementation"

--- a/contracts/pair/Cargo.toml
+++ b/contracts/pair/Cargo.toml
@@ -7,6 +7,7 @@ description = "The Astroport constant product pool contract implementation"
 license = "GPL-3.0-only"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
+metadata = { build_variants = ["injective", "sei"] }
 
 exclude = [
     # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.

--- a/contracts/pair/src/contract.rs
+++ b/contracts/pair/src/contract.rs
@@ -21,7 +21,6 @@ use astroport::asset::{
     MINIMUM_LIQUIDITY_AMOUNT,
 };
 use astroport::common::LP_SUBDENOM;
-use astroport::factory::PairType;
 use astroport::incentives::ExecuteMsg as IncentiveExecuteMsg;
 use astroport::pair::{
     ConfigResponse, FeeShareConfig, ReplyIds, XYKPoolConfig, XYKPoolParams, XYKPoolUpdateParams,
@@ -80,7 +79,7 @@ pub fn instantiate(
             contract_addr: env.contract.address.clone(),
             liquidity_token: "".to_owned(),
             asset_infos: msg.asset_infos.clone(),
-            pair_type: PairType::Xyk {},
+            pair_type: msg.pair_type,
         },
         factory_addr: deps.api.addr_validate(msg.factory_addr.as_str())?,
         block_time_last: 0,

--- a/contracts/pair/src/testing.rs
+++ b/contracts/pair/src/testing.rs
@@ -62,6 +62,7 @@ fn proper_initialization() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Xyk {},
         factory_addr: String::from("factory"),
         asset_infos: vec![
             AssetInfo::NativeToken {
@@ -140,6 +141,7 @@ fn provide_liquidity() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Xyk {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -671,6 +673,7 @@ fn withdraw_liquidity() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Xyk {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -812,6 +815,7 @@ fn try_native_to_token() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Xyk {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1019,6 +1023,7 @@ fn try_token_to_native() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Xyk {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1274,6 +1279,7 @@ fn test_query_pool() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Xyk {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1342,6 +1348,7 @@ fn test_query_share() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Xyk {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),

--- a/contracts/pair_astro_converter/Cargo.toml
+++ b/contracts/pair_astro_converter/Cargo.toml
@@ -42,6 +42,6 @@ derivative = "2.2"
 itertools.workspace = true
 cw-multi-test = "0.20.0"
 cw20-base = "1.1"
-astroport-factory = { path = "../factory" }
+astroport-factory = "1.8"
 astroport-pair = "~1.3.3"
 astro-token-converter = { path = "../periphery/astro_converter", version = "1.0" }

--- a/contracts/pair_concentrated/Cargo.toml
+++ b/contracts/pair_concentrated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-concentrated"
-version = "4.0.2"
+version = "4.1.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport concentrated liquidity pair"

--- a/contracts/pair_concentrated/src/contract.rs
+++ b/contracts/pair_concentrated/src/contract.rs
@@ -20,7 +20,6 @@ use astroport::asset::{
 };
 use astroport::common::{claim_ownership, drop_ownership_proposal, propose_new_owner, LP_SUBDENOM};
 use astroport::cosmwasm_ext::{DecimalToInteger, IntegerToDecimal};
-use astroport::factory::PairType;
 use astroport::observation::{PrecommitObservation, OBSERVATIONS_SIZE};
 use astroport::pair::{
     Cw20HookMsg, ExecuteMsg, FeeShareConfig, InstantiateMsg, ReplyIds, MAX_FEE_SHARE_BPS,
@@ -132,7 +131,7 @@ pub fn instantiate(
             contract_addr: env.contract.address.clone(),
             liquidity_token: "".to_owned(),
             asset_infos: msg.asset_infos.clone(),
-            pair_type: PairType::Custom("concentrated".to_string()),
+            pair_type: msg.pair_type,
         },
         factory_addr,
         block_time_last: env.block.time.seconds(),

--- a/contracts/pair_stable/Cargo.toml
+++ b/contracts/pair_stable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-stable"
-version = "4.0.1"
+version = "4.1.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "The Astroport stableswap pair contract implementation"

--- a/contracts/pair_stable/Cargo.toml
+++ b/contracts/pair_stable/Cargo.toml
@@ -7,6 +7,7 @@ description = "The Astroport stableswap pair contract implementation"
 license = "GPL-3.0-only"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
+metadata = { build_variants = ["injective", "sei"] }
 
 exclude = [
     # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.

--- a/contracts/pair_stable/src/contract.rs
+++ b/contracts/pair_stable/src/contract.rs
@@ -20,7 +20,6 @@ use astroport::asset::{
 };
 use astroport::common::{claim_ownership, drop_ownership_proposal, propose_new_owner, LP_SUBDENOM};
 use astroport::cosmwasm_ext::IntegerToDecimal;
-use astroport::factory::PairType;
 use astroport::observation::{query_observation, PrecommitObservation, OBSERVATIONS_SIZE};
 use astroport::pair::{
     ConfigResponse, CumulativePricesResponse, FeeShareConfig, InstantiateMsg, StablePoolParams,
@@ -104,7 +103,7 @@ pub fn instantiate(
             contract_addr: env.contract.address.clone(),
             liquidity_token: "".to_owned(),
             asset_infos: msg.asset_infos.clone(),
-            pair_type: PairType::Stable {},
+            pair_type: msg.pair_type,
         },
         factory_addr,
         block_time_last: 0,

--- a/contracts/pair_stable/src/testing.rs
+++ b/contracts/pair_stable/src/testing.rs
@@ -12,6 +12,7 @@ use sim::StableSwapModel;
 
 use astroport::asset::{native_asset, native_asset_info, Asset, AssetInfo};
 use astroport::common::LP_SUBDENOM;
+use astroport::factory::PairType;
 use astroport::observation::query_observation;
 use astroport::observation::Observation;
 use astroport::observation::OracleObservation;
@@ -67,6 +68,7 @@ fn proper_initialization() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         factory_addr: String::from("factory"),
         asset_infos: vec![
             AssetInfo::NativeToken {
@@ -152,6 +154,7 @@ fn provide_liquidity() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -547,6 +550,7 @@ fn withdraw_liquidity() {
     let info = mock_info("addr0000", &[]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -693,6 +697,7 @@ fn try_native_to_token() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -850,6 +855,7 @@ fn try_token_to_native() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1077,6 +1083,7 @@ fn test_query_pool() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1151,6 +1158,7 @@ fn test_query_share() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1350,6 +1358,7 @@ proptest! {
         let ask_asset = native_asset_info("uluna".to_string());
 
         let msg = InstantiateMsg {
+            pair_type: PairType::Stable {},
             factory_addr: String::from("factory"),
             asset_infos: vec![offer_asset.info.clone(), ask_asset.clone()],
             token_code_id: 10u64,
@@ -1429,6 +1438,7 @@ fn update_owner() {
     let owner = "owner0000";
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "ucosmos".to_string(),

--- a/contracts/pair_stable/tests/integration.rs
+++ b/contracts/pair_stable/tests/integration.rs
@@ -166,6 +166,7 @@ fn instantiate_pair(mut router: &mut TestApp, owner: &Addr) -> Addr {
         .unwrap();
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -195,6 +196,7 @@ fn instantiate_pair(mut router: &mut TestApp, owner: &Addr) -> Addr {
     );
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1254,6 +1256,7 @@ fn create_pair_with_same_assets() {
     let pair_contract_code_id = store_pair_code(&mut router);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1334,6 +1337,7 @@ fn update_pair_config() {
         .unwrap();
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1582,6 +1586,7 @@ fn enable_disable_fee_sharing() {
         .unwrap();
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Stable {},
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),

--- a/contracts/pair_transmuter/Cargo.toml
+++ b/contracts/pair_transmuter/Cargo.toml
@@ -7,6 +7,7 @@ description = "The Astroport constant sum pair contract implementation. Handles 
 license = "GPL-3.0-only"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
+metadata = { build_variants = ["injective", "sei"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/pair_xyk_sale_tax/Cargo.toml
+++ b/contracts/pair_xyk_sale_tax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-pair-xyk-sale-tax"
-version = "2.0.2"
+version = "2.1.0"
 authors = ["Astroport", "Sturdy"]
 edition = "2021"
 description = "The Astroport constant product pool contract implementation"

--- a/contracts/pair_xyk_sale_tax/Cargo.toml
+++ b/contracts/pair_xyk_sale_tax/Cargo.toml
@@ -7,6 +7,7 @@ description = "The Astroport constant product pool contract implementation"
 license = "Apache-2.0"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
+metadata = { build_variants = ["injective", "sei"] }
 
 exclude = [
     # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -45,7 +45,7 @@ use crate::error::ContractError;
 use crate::state::{Config, BALANCES, CONFIG};
 
 /// Contract name that is used for migration.
-const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+pub const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 /// Contract version that is used for migration.
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Reply ID for create denom reply

--- a/contracts/pair_xyk_sale_tax/src/testing.rs
+++ b/contracts/pair_xyk_sale_tax/src/testing.rs
@@ -20,7 +20,7 @@ use astroport::token_factory::{MsgBurn, MsgCreateDenom, MsgCreateDenomResponse, 
 
 use crate::contract::{
     accumulate_prices, assert_max_spread, compute_swap, execute, instantiate, query_pool,
-    query_reverse_simulation, query_share, query_simulation, reply,
+    query_reverse_simulation, query_share, query_simulation, reply, CONTRACT_NAME,
 };
 use crate::contract::{compute_offer_amount, SwapResult};
 use crate::error::ContractError;
@@ -62,6 +62,7 @@ fn proper_initialization() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         factory_addr: String::from("factory"),
         asset_infos: vec![
             AssetInfo::NativeToken {
@@ -138,6 +139,7 @@ fn provide_liquidity() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -655,6 +657,7 @@ fn withdraw_liquidity() {
     let info = mock_info("addr0000", &[]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -796,6 +799,7 @@ fn try_native_to_token() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1025,6 +1029,7 @@ fn try_token_to_native() {
     ]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1280,6 +1285,7 @@ fn test_query_pool() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1348,6 +1354,7 @@ fn test_query_share() {
     )]);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),

--- a/contracts/pair_xyk_sale_tax/tests/integration.rs
+++ b/contracts/pair_xyk_sale_tax/tests/integration.rs
@@ -18,6 +18,7 @@ use astroport::tokenfactory_tracker::{
 };
 
 use astroport::common::LP_SUBDENOM;
+use astroport_pair_xyk_sale_tax::contract::CONTRACT_NAME;
 use astroport_pair_xyk_sale_tax::error::ContractError;
 use astroport_test::cw_multi_test::{AppBuilder, ContractWrapper, Executor, TOKEN_FACTORY_MODULE};
 use astroport_test::modules::stargate::{MockStargate, StargateApp as TestApp};
@@ -165,6 +166,7 @@ fn instantiate_pair(mut router: &mut TestApp, owner: &Addr) -> Addr {
         .unwrap();
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -239,6 +241,7 @@ fn instantiate_standard_xyk_pair(mut router: &mut TestApp, owner: &Addr, version
         .unwrap();
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -938,6 +941,7 @@ fn create_pair_with_same_assets() {
     let pair_contract_code_id = store_pair_code(&mut router);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -976,6 +980,7 @@ fn wrong_number_of_assets() {
     let pair_contract_code_id = store_pair_code(&mut router);
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![AssetInfo::NativeToken {
             denom: "uusd".to_string(),
         }],
@@ -1001,6 +1006,7 @@ fn wrong_number_of_assets() {
     );
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             native_asset_info("uusd".to_string()),
             native_asset_info("dust".to_string()),
@@ -1411,6 +1417,7 @@ fn update_pair_config() {
         .unwrap();
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),
@@ -1499,6 +1506,7 @@ fn update_tax_configs() {
         .unwrap();
 
     let msg = InstantiateMsg {
+        pair_type: PairType::Custom(CONTRACT_NAME.to_string()),
         asset_infos: vec![
             AssetInfo::NativeToken {
                 denom: "uusd".to_string(),

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport"
-version = "5.4.0"
+version = "5.5.0"
 authors = ["Astroport"]
 edition = "2021"
 description = "Common Astroport types, queriers and other utils"

--- a/packages/astroport/src/pair.rs
+++ b/packages/astroport/src/pair.rs
@@ -3,6 +3,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 
 use crate::asset::{Asset, AssetInfo, PairInfo};
 
+use crate::factory::PairType;
 use cosmwasm_std::{Addr, Binary, Decimal, Decimal256, StdError, Uint128, Uint64};
 use cw20::Cw20ReceiveMsg;
 
@@ -23,6 +24,8 @@ pub const MIN_TRADE_SIZE: Decimal256 = Decimal256::raw(10000000000000);
 /// This structure describes the parameters used for creating a contract.
 #[cw_serde]
 pub struct InstantiateMsg {
+    /// The pair type
+    pub pair_type: PairType,
     /// Information about assets in the pool
     pub asset_infos: Vec<AssetInfo>,
     /// The token contract code ID used for the tokens in the pool
@@ -309,16 +312,7 @@ impl TryFrom<u64> for ReplyIds {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::asset::native_asset_info;
     use cosmwasm_std::{from_json, to_json_binary};
-
-    #[cw_serde]
-    pub struct LegacyInstantiateMsg {
-        pub asset_infos: [AssetInfo; 2],
-        pub token_code_id: u64,
-        pub factory_addr: String,
-        pub init_params: Option<Binary>,
-    }
 
     #[cw_serde]
     pub struct LegacyConfigResponse {
@@ -326,23 +320,6 @@ mod tests {
         pub params: Option<Binary>,
         pub factory_addr: Addr,
         pub owner: Addr,
-    }
-
-    #[test]
-    fn test_init_msg_compatability() {
-        let inst_msg = LegacyInstantiateMsg {
-            asset_infos: [
-                native_asset_info("uusd".to_string()),
-                native_asset_info("uluna".to_string()),
-            ],
-            token_code_id: 0,
-            factory_addr: "factory".to_string(),
-            init_params: None,
-        };
-
-        let ser_msg = to_json_binary(&inst_msg).unwrap();
-        // This .unwrap() is enough to make sure that [AssetInfo; 2] and Vec<AssetInfo> are compatible.
-        let _: InstantiateMsg = from_json(&ser_msg).unwrap();
     }
 
     #[test]

--- a/schemas/astroport-factory/astroport-factory.json
+++ b/schemas/astroport-factory/astroport-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "astroport-factory",
-  "contract_version": "1.8.1",
+  "contract_version": "1.9.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/astroport-pair-concentrated/astroport-pair-concentrated.json
+++ b/schemas/astroport-pair-concentrated/astroport-pair-concentrated.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "astroport-pair-concentrated",
-  "contract_version": "4.0.2",
+  "contract_version": "4.1.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10,6 +10,7 @@
     "required": [
       "asset_infos",
       "factory_addr",
+      "pair_type",
       "token_code_id"
     ],
     "properties": {
@@ -32,6 +33,14 @@
           },
           {
             "type": "null"
+          }
+        ]
+      },
+      "pair_type": {
+        "description": "The pair type",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PairType"
           }
         ]
       },
@@ -100,6 +109,52 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "PairType": {
+        "description": "This enum describes available pair types. ## Available pool types ``` # use astroport::factory::PairType::{Custom, Stable, Xyk}; Xyk {}; Stable {}; Custom(String::from(\"Custom\")); ```",
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     }
   },

--- a/schemas/astroport-pair-concentrated/raw/instantiate.json
+++ b/schemas/astroport-pair-concentrated/raw/instantiate.json
@@ -6,6 +6,7 @@
   "required": [
     "asset_infos",
     "factory_addr",
+    "pair_type",
     "token_code_id"
   ],
   "properties": {
@@ -28,6 +29,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "pair_type": {
+      "description": "The pair type",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PairType"
         }
       ]
     },
@@ -96,6 +105,52 @@
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
+    },
+    "PairType": {
+      "description": "This enum describes available pair types. ## Available pool types ``` # use astroport::factory::PairType::{Custom, Stable, Xyk}; Xyk {}; Stable {}; Custom(String::from(\"Custom\")); ```",
+      "oneOf": [
+        {
+          "description": "XYK pair type",
+          "type": "object",
+          "required": [
+            "xyk"
+          ],
+          "properties": {
+            "xyk": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Stable pair type",
+          "type": "object",
+          "required": [
+            "stable"
+          ],
+          "properties": {
+            "stable": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Custom pair type",
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   }
 }

--- a/schemas/astroport-pair-stable/astroport-pair-stable.json
+++ b/schemas/astroport-pair-stable/astroport-pair-stable.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "astroport-pair-stable",
-  "contract_version": "4.0.1",
+  "contract_version": "4.1.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10,6 +10,7 @@
     "required": [
       "asset_infos",
       "factory_addr",
+      "pair_type",
       "token_code_id"
     ],
     "properties": {
@@ -32,6 +33,14 @@
           },
           {
             "type": "null"
+          }
+        ]
+      },
+      "pair_type": {
+        "description": "The pair type",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PairType"
           }
         ]
       },
@@ -100,6 +109,52 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "PairType": {
+        "description": "This enum describes available pair types. ## Available pool types ``` # use astroport::factory::PairType::{Custom, Stable, Xyk}; Xyk {}; Stable {}; Custom(String::from(\"Custom\")); ```",
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     }
   },

--- a/schemas/astroport-pair-stable/raw/instantiate.json
+++ b/schemas/astroport-pair-stable/raw/instantiate.json
@@ -6,6 +6,7 @@
   "required": [
     "asset_infos",
     "factory_addr",
+    "pair_type",
     "token_code_id"
   ],
   "properties": {
@@ -28,6 +29,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "pair_type": {
+      "description": "The pair type",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PairType"
         }
       ]
     },
@@ -96,6 +105,52 @@
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
+    },
+    "PairType": {
+      "description": "This enum describes available pair types. ## Available pool types ``` # use astroport::factory::PairType::{Custom, Stable, Xyk}; Xyk {}; Stable {}; Custom(String::from(\"Custom\")); ```",
+      "oneOf": [
+        {
+          "description": "XYK pair type",
+          "type": "object",
+          "required": [
+            "xyk"
+          ],
+          "properties": {
+            "xyk": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Stable pair type",
+          "type": "object",
+          "required": [
+            "stable"
+          ],
+          "properties": {
+            "stable": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Custom pair type",
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   }
 }

--- a/schemas/astroport-pair-xyk-sale-tax/astroport-pair-xyk-sale-tax.json
+++ b/schemas/astroport-pair-xyk-sale-tax/astroport-pair-xyk-sale-tax.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "astroport-pair-xyk-sale-tax",
-  "contract_version": "2.0.2",
+  "contract_version": "2.1.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10,6 +10,7 @@
     "required": [
       "asset_infos",
       "factory_addr",
+      "pair_type",
       "token_code_id"
     ],
     "properties": {
@@ -32,6 +33,14 @@
           },
           {
             "type": "null"
+          }
+        ]
+      },
+      "pair_type": {
+        "description": "The pair type",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PairType"
           }
         ]
       },
@@ -100,6 +109,52 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "PairType": {
+        "description": "This enum describes available pair types. ## Available pool types ``` # use astroport::factory::PairType::{Custom, Stable, Xyk}; Xyk {}; Stable {}; Custom(String::from(\"Custom\")); ```",
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     }
   },

--- a/schemas/astroport-pair-xyk-sale-tax/raw/instantiate.json
+++ b/schemas/astroport-pair-xyk-sale-tax/raw/instantiate.json
@@ -6,6 +6,7 @@
   "required": [
     "asset_infos",
     "factory_addr",
+    "pair_type",
     "token_code_id"
   ],
   "properties": {
@@ -28,6 +29,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "pair_type": {
+      "description": "The pair type",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PairType"
         }
       ]
     },
@@ -96,6 +105,52 @@
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
+    },
+    "PairType": {
+      "description": "This enum describes available pair types. ## Available pool types ``` # use astroport::factory::PairType::{Custom, Stable, Xyk}; Xyk {}; Stable {}; Custom(String::from(\"Custom\")); ```",
+      "oneOf": [
+        {
+          "description": "XYK pair type",
+          "type": "object",
+          "required": [
+            "xyk"
+          ],
+          "properties": {
+            "xyk": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Stable pair type",
+          "type": "object",
+          "required": [
+            "stable"
+          ],
+          "properties": {
+            "stable": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Custom pair type",
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   }
 }

--- a/schemas/astroport-pair/astroport-pair.json
+++ b/schemas/astroport-pair/astroport-pair.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "astroport-pair",
-  "contract_version": "2.0.2",
+  "contract_version": "2.1.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10,6 +10,7 @@
     "required": [
       "asset_infos",
       "factory_addr",
+      "pair_type",
       "token_code_id"
     ],
     "properties": {
@@ -32,6 +33,14 @@
           },
           {
             "type": "null"
+          }
+        ]
+      },
+      "pair_type": {
+        "description": "The pair type",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PairType"
           }
         ]
       },
@@ -100,6 +109,52 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "PairType": {
+        "description": "This enum describes available pair types. ## Available pool types ``` # use astroport::factory::PairType::{Custom, Stable, Xyk}; Xyk {}; Stable {}; Custom(String::from(\"Custom\")); ```",
+        "oneOf": [
+          {
+            "description": "XYK pair type",
+            "type": "object",
+            "required": [
+              "xyk"
+            ],
+            "properties": {
+              "xyk": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Stable pair type",
+            "type": "object",
+            "required": [
+              "stable"
+            ],
+            "properties": {
+              "stable": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Custom pair type",
+            "type": "object",
+            "required": [
+              "custom"
+            ],
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       }
     }
   },

--- a/schemas/astroport-pair/raw/instantiate.json
+++ b/schemas/astroport-pair/raw/instantiate.json
@@ -6,6 +6,7 @@
   "required": [
     "asset_infos",
     "factory_addr",
+    "pair_type",
     "token_code_id"
   ],
   "properties": {
@@ -28,6 +29,14 @@
         },
         {
           "type": "null"
+        }
+      ]
+    },
+    "pair_type": {
+      "description": "The pair type",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PairType"
         }
       ]
     },
@@ -96,6 +105,52 @@
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
+    },
+    "PairType": {
+      "description": "This enum describes available pair types. ## Available pool types ``` # use astroport::factory::PairType::{Custom, Stable, Xyk}; Xyk {}; Stable {}; Custom(String::from(\"Custom\")); ```",
+      "oneOf": [
+        {
+          "description": "XYK pair type",
+          "type": "object",
+          "required": [
+            "xyk"
+          ],
+          "properties": {
+            "xyk": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Stable pair type",
+          "type": "object",
+          "required": [
+            "stable"
+          ],
+          "properties": {
+            "stable": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Custom pair type",
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   }
 }

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -8,4 +8,4 @@ projectPath=$(cd "$(dirname "${0}")" && cd ../ && pwd)
 docker run --rm -v "$projectPath":/code \
   --mount type=volume,source="$(basename "$projectPath")_cache",target=/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/optimizer:0.15.1
+  ghcr.io/astroport-fi/rust-optimizer:v0.15.1-astroport


### PR DESCRIPTION
Instead of hardcoding pair type in instantiation endpoint per each pool contract implementation we're making factory sending pair type.

This PR also enables conditional compilation for Injective and Sei allowing to use their custom protobuf encoding pathes for tokenfactory messages.