### PR TITLE
chore: remove Sei support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![codecov](https://codecov.io/gh/astroport-fi/astroport-core/branch/main/graph/badge.svg?token=ROOLZTGZMM)](https://codecov.io/gh/astroport-fi/astroport-core)
 
-Multi pool type automated market-maker (AMM) protocol powered by smart contracts on the Terra, Injective, Neutron, Sei
+Multi pool type automated market-maker (AMM) protocol powered by smart contracts on the Terra, Injective, Neutron,
 and Osmosis
 blockchains.
 

--- a/contracts/pair/Cargo.toml
+++ b/contracts/pair/Cargo.toml
@@ -7,7 +7,7 @@ description = "The Astroport constant product pool contract implementation"
 license = "GPL-3.0-only"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
-metadata = { build_variants = ["injective", "sei"] }
+metadata = { build_variants = ["injective"] }
 
 exclude = [
     # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -25,7 +25,6 @@ crate-type = ["cdylib", "rlib"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 injective = ["astroport/injective"]
-sei = ["astroport/sei"]
 library = []
 
 [dependencies]

--- a/contracts/pair/src/contract.rs
+++ b/contracts/pair/src/contract.rs
@@ -127,7 +127,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                 let tracking = config.track_asset_balances;
                 let mut sub_msgs = vec![];
 
-                #[cfg(any(feature = "injective", feature = "sei"))]
+                #[cfg(feature = "injective")]
                 let tracking = false;
 
                 if tracking {

--- a/contracts/pair/src/testing.rs
+++ b/contracts/pair/src/testing.rs
@@ -88,7 +88,6 @@ fn proper_initialization() {
                 type_url: MsgCreateDenom::TYPE_URL.to_string(),
                 value: Binary(
                     MsgCreateDenom {
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
                         subdenom: LP_SUBDENOM.to_string()
                     }
@@ -228,9 +227,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(1000_u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from(MOCK_CONTRACT_ADDR),
                     }
                     .encode_to_vec()
@@ -252,9 +250,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(99_999999999999999000u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from("addr0000"),
                     }
                     .encode_to_vec()
@@ -355,9 +352,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(50_000000000000000000u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from("addr0000"),
                     }
                     .encode_to_vec()
@@ -763,13 +759,12 @@ fn withdraw_liquidity() {
                 type_url: MsgBurn::TYPE_URL.to_string(),
                 value: Binary::from(
                     MsgBurn {
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
                         amount: Some(astroport::token_factory::ProtoCoin {
                             denom: denom.to_string(),
                             amount: Uint128::from(100u128).to_string(),
                         }),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         burn_from_address: "".to_string()
                     }
                     .encode_to_vec()

--- a/contracts/pair_concentrated/Cargo.toml
+++ b/contracts/pair_concentrated/Cargo.toml
@@ -7,7 +7,7 @@ description = "The Astroport concentrated liquidity pair"
 license = "GPL-3.0-only"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
-metadata = { build_variants = ["injective", "sei"] }
+metadata = { build_variants = ["injective"] }
 
 exclude = [
     # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -25,8 +25,7 @@ crate-type = ["cdylib", "rlib"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 library = []
-injective = ["astroport/injective", "astroport-pcl-common/injective"]
-sei = ["astroport/sei", "astroport-pcl-common/sei"]
+injective = ["astroport/injective"]
 
 [dependencies]
 astroport.workspace = true

--- a/contracts/pair_concentrated/src/contract.rs
+++ b/contracts/pair_concentrated/src/contract.rs
@@ -186,7 +186,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                 let tracking = config.track_asset_balances;
                 let mut sub_msgs = vec![];
 
-                #[cfg(any(feature = "injective", feature = "sei"))]
+                #[cfg(feature = "injective")]
                 let tracking = false;
 
                 if tracking {

--- a/contracts/pair_concentrated_sale_tax/Cargo.toml
+++ b/contracts/pair_concentrated_sale_tax/Cargo.toml
@@ -7,7 +7,7 @@ description = "The Astroport concentrated liquidity pair"
 license = "GPL-3.0-only"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
-metadata = { build_variants = ["injective", "sei"] }
+metadata = { build_variants = ["injective"] }
 
 exclude = [
     # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -25,8 +25,7 @@ crate-type = ["cdylib", "rlib"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 library = []
-injective = ["astroport/injective", "astroport-pcl-common/injective"]
-sei = ["astroport/sei", "astroport-pcl-common/sei"]
+injective = ["astroport/injective"]
 
 [dependencies]
 astroport.workspace = true

--- a/contracts/pair_concentrated_sale_tax/src/contract.rs
+++ b/contracts/pair_concentrated_sale_tax/src/contract.rs
@@ -196,7 +196,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                 let tracking = config.track_asset_balances;
                 let mut sub_msgs = vec![];
 
-                #[cfg(any(feature = "injective", feature = "sei"))]
+                #[cfg(feature = "injective")]
                 let tracking = false;
 
                 if tracking {

--- a/contracts/pair_stable/Cargo.toml
+++ b/contracts/pair_stable/Cargo.toml
@@ -7,7 +7,7 @@ description = "The Astroport stableswap pair contract implementation"
 license = "GPL-3.0-only"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
-metadata = { build_variants = ["injective", "sei"] }
+metadata = { build_variants = ["injective"] }
 
 exclude = [
     # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -25,7 +25,6 @@ crate-type = ["cdylib", "rlib"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 injective = ["astroport/injective"]
-sei = ["astroport/sei"]
 library = []
 
 [dependencies]

--- a/contracts/pair_stable/src/testing.rs
+++ b/contracts/pair_stable/src/testing.rs
@@ -101,7 +101,6 @@ fn proper_initialization() {
                 type_url: MsgCreateDenom::TYPE_URL.to_string(),
                 value: Binary(
                     MsgCreateDenom {
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
                         subdenom: LP_SUBDENOM.to_string()
                     }
@@ -250,9 +249,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(1000_u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from(MOCK_CONTRACT_ADDR),
                     }
                     .encode_to_vec()
@@ -275,9 +273,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(299_814_698_523_989_456_628u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from("addr0000"),
                     }
                     .encode_to_vec()
@@ -374,9 +371,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(74_981_956_874_579_206461u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from("addr0000"),
                     }
                     .encode_to_vec()
@@ -645,13 +641,12 @@ fn withdraw_liquidity() {
                 type_url: MsgBurn::TYPE_URL.to_string(),
                 value: Binary::from(
                     MsgBurn {
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
                         amount: Some(astroport::token_factory::ProtoCoin {
                             denom: denom.to_string(),
                             amount: Uint128::from(100u128).to_string(),
                         }),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         burn_from_address: "".to_string()
                     }
                     .encode_to_vec()

--- a/contracts/pair_transmuter/Cargo.toml
+++ b/contracts/pair_transmuter/Cargo.toml
@@ -7,7 +7,7 @@ description = "The Astroport constant sum pair contract implementation. Handles 
 license = "GPL-3.0-only"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
-metadata = { build_variants = ["injective", "sei"] }
+metadata = { build_variants = ["injective"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -15,7 +15,6 @@ crate-type = ["cdylib", "rlib"]
 [features]
 library = []
 injective = ["astroport/injective"]
-sei = ["astroport/sei"]
 
 [dependencies]
 astroport.workspace = true

--- a/contracts/pair_xyk_sale_tax/Cargo.toml
+++ b/contracts/pair_xyk_sale_tax/Cargo.toml
@@ -7,7 +7,7 @@ description = "The Astroport constant product pool contract implementation"
 license = "Apache-2.0"
 repository = "https://github.com/astroport-fi/astroport"
 homepage = "https://astroport.fi"
-metadata = { build_variants = ["injective", "sei"] }
+metadata = { build_variants = ["injective"] }
 
 exclude = [
     # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -25,7 +25,6 @@ crate-type = ["cdylib", "rlib"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 injective = ["astroport/injective"]
-sei = ["astroport/sei"]
 library = []
 
 [dependencies]

--- a/contracts/pair_xyk_sale_tax/src/contract.rs
+++ b/contracts/pair_xyk_sale_tax/src/contract.rs
@@ -127,7 +127,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                 let tracking = config.track_asset_balances;
                 let mut sub_msgs = vec![];
 
-                #[cfg(any(feature = "injective", feature = "sei"))]
+                #[cfg(feature = "injective")]
                 let tracking = false;
 
                 if tracking {

--- a/contracts/pair_xyk_sale_tax/src/testing.rs
+++ b/contracts/pair_xyk_sale_tax/src/testing.rs
@@ -88,7 +88,6 @@ fn proper_initialization() {
                 type_url: MsgCreateDenom::TYPE_URL.to_string(),
                 value: Binary(
                     MsgCreateDenom {
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
                         subdenom: LP_SUBDENOM.to_string()
                     }
@@ -226,9 +225,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(1000_u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from(MOCK_CONTRACT_ADDR),
                     }
                     .encode_to_vec()
@@ -250,9 +248,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(99_999999999999999000u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from("addr0000"),
                     }
                     .encode_to_vec()
@@ -350,9 +347,8 @@ fn provide_liquidity() {
                             denom: denom.to_string(),
                             amount: Uint128::from(50_000000000000000000u128).to_string(),
                         }),
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         mint_to_address: String::from("addr0000"),
                     }
                     .encode_to_vec()
@@ -747,13 +743,12 @@ fn withdraw_liquidity() {
                 type_url: MsgBurn::TYPE_URL.to_string(),
                 value: Binary::from(
                     MsgBurn {
-                        #[cfg(not(feature = "sei"))]
                         sender: env.contract.address.to_string(),
                         amount: Some(astroport::token_factory::ProtoCoin {
                             denom: denom.to_string(),
                             amount: Uint128::from(100u128).to_string(),
                         }),
-                        #[cfg(not(any(feature = "injective", feature = "sei")))]
+                        #[cfg(not(feature = "injective"))]
                         burn_from_address: "".to_string()
                     }
                     .encode_to_vec()

--- a/packages/astroport/Cargo.toml
+++ b/packages/astroport/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://astroport.fi"
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 injective = ["injective-math", "thiserror"]
-sei = []
 duality = []
 
 [dependencies]

--- a/packages/astroport/src/token_factory.rs
+++ b/packages/astroport/src/token_factory.rs
@@ -1,7 +1,7 @@
 pub use cosmos_sdk_proto::cosmos::base::v1beta1::Coin as ProtoCoin;
 use cosmwasm_std::{Binary, Coin, CosmosMsg, CustomMsg, StdError};
 
-#[cfg(any(feature = "injective", feature = "sei"))]
+#[cfg(feature = "injective")]
 use cosmwasm_std::BankMsg;
 
 use prost::Message;
@@ -42,7 +42,6 @@ impl TryFrom<Binary> for MsgCreateDenomResponse {
     }
 }
 
-#[cfg(not(any(feature = "sei")))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgCreateDenom {
     #[prost(string, tag = "1")]
@@ -52,21 +51,11 @@ pub struct MsgCreateDenom {
     pub subdenom: ::prost::alloc::string::String,
 }
 
-#[cfg(feature = "sei")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgCreateDenom {
-    /// subdenom can be up to 44 "alphanumeric" characters long.
-    #[prost(string, tag = "2")]
-    pub subdenom: ::prost::alloc::string::String,
-}
-
 impl MsgCreateDenom {
-    #[cfg(not(any(feature = "injective", feature = "sei")))]
+    #[cfg(not(feature = "injective"))]
     pub const TYPE_URL: &'static str = "/osmosis.tokenfactory.v1beta1.MsgCreateDenom";
     #[cfg(feature = "injective")]
     pub const TYPE_URL: &'static str = "/injective.tokenfactory.v1beta1.MsgCreateDenom";
-    #[cfg(feature = "sei")]
-    pub const TYPE_URL: &'static str = "/seiprotocol.seichain.tokenfactory.v1beta1.MsgCreateDenom";
 }
 
 impl TryFrom<Binary> for MsgCreateDenom {
@@ -83,7 +72,7 @@ impl TryFrom<Binary> for MsgCreateDenom {
     }
 }
 
-#[cfg(not(any(feature = "injective", feature = "sei")))]
+#[cfg(not(feature = "injective"))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgBurn {
     #[prost(string, tag = "1")]
@@ -103,20 +92,11 @@ pub struct MsgBurn {
     pub amount: ::core::option::Option<cosmos_sdk_proto::cosmos::base::v1beta1::Coin>,
 }
 
-#[cfg(feature = "sei")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgBurn {
-    #[prost(message, optional, tag = "2")]
-    pub amount: ::core::option::Option<cosmos_sdk_proto::cosmos::base::v1beta1::Coin>,
-}
-
 impl MsgBurn {
-    #[cfg(not(any(feature = "injective", feature = "sei")))]
+    #[cfg(not(feature = "injective"))]
     pub const TYPE_URL: &'static str = "/osmosis.tokenfactory.v1beta1.MsgBurn";
     #[cfg(feature = "injective")]
     pub const TYPE_URL: &'static str = "/injective.tokenfactory.v1beta1.MsgBurn";
-    #[cfg(feature = "sei")]
-    pub const TYPE_URL: &'static str = "/seiprotocol.seichain.tokenfactory.v1beta1.MsgBurn";
 }
 
 impl TryFrom<Binary> for MsgBurn {
@@ -133,7 +113,7 @@ impl TryFrom<Binary> for MsgBurn {
     }
 }
 
-#[cfg(not(any(feature = "injective", feature = "sei")))]
+#[cfg(not(feature = "injective"))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgMint {
     #[prost(string, tag = "1")]
@@ -153,20 +133,11 @@ pub struct MsgMint {
     pub amount: ::core::option::Option<cosmos_sdk_proto::cosmos::base::v1beta1::Coin>,
 }
 
-#[cfg(feature = "sei")]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MsgMint {
-    #[prost(message, optional, tag = "2")]
-    pub amount: ::core::option::Option<cosmos_sdk_proto::cosmos::base::v1beta1::Coin>,
-}
-
 impl MsgMint {
-    #[cfg(not(any(feature = "injective", feature = "sei")))]
+    #[cfg(not(feature = "injective"))]
     pub const TYPE_URL: &'static str = "/osmosis.tokenfactory.v1beta1.MsgMint";
     #[cfg(feature = "injective")]
     pub const TYPE_URL: &'static str = "/injective.tokenfactory.v1beta1.MsgMint";
-    #[cfg(feature = "sei")]
-    pub const TYPE_URL: &'static str = "/seiprotocol.seichain.tokenfactory.v1beta1.MsgMint";
 }
 
 impl TryFrom<Binary> for MsgMint {
@@ -215,14 +186,8 @@ pub fn tf_create_denom_msg<T>(sender: impl Into<String>, denom: impl Into<String
 where
     T: CustomMsg,
 {
-    #[cfg(not(any(feature = "sei")))]
     let create_denom_msg = MsgCreateDenom {
         sender: sender.into(),
-        subdenom: denom.into(),
-    };
-
-    #[cfg(feature = "sei")]
-    let create_denom_msg = MsgCreateDenom {
         subdenom: denom.into(),
     };
 
@@ -243,7 +208,7 @@ where
     let sender_addr: String = sender.into();
     let receiver_addr: String = receiver.into();
 
-    #[cfg(not(any(feature = "injective", feature = "sei")))]
+    #[cfg(not(feature = "injective"))]
     let mint_msg = MsgMint {
         sender: sender_addr.clone(),
         amount: Some(ProtoCoin {
@@ -262,21 +227,13 @@ where
         }),
     };
 
-    #[cfg(feature = "sei")]
-    let mint_msg = MsgMint {
-        amount: Some(ProtoCoin {
-            denom: coin.denom.to_string(),
-            amount: coin.amount.to_string(),
-        }),
-    };
-
-    #[cfg(not(any(feature = "injective", feature = "sei")))]
+    #[cfg(not(feature = "injective"))]
     return vec![CosmosMsg::Stargate {
         type_url: MsgMint::TYPE_URL.to_string(),
         value: Binary::from(mint_msg.encode_to_vec()),
     }];
 
-    #[cfg(any(feature = "injective", feature = "sei"))]
+    #[cfg(feature = "injective")]
     if sender_addr == receiver_addr {
         vec![CosmosMsg::Stargate {
             type_url: MsgMint::TYPE_URL.to_string(),
@@ -301,7 +258,7 @@ pub fn tf_burn_msg<T>(sender: impl Into<String>, coin: Coin) -> CosmosMsg<T>
 where
     T: CustomMsg,
 {
-    #[cfg(not(any(feature = "injective", feature = "sei")))]
+    #[cfg(not(feature = "injective"))]
     let burn_msg = MsgBurn {
         sender: sender.into(),
         amount: Some(ProtoCoin {
@@ -314,14 +271,6 @@ where
     #[cfg(feature = "injective")]
     let burn_msg = MsgBurn {
         sender: sender.into(),
-        amount: Some(ProtoCoin {
-            denom: coin.denom,
-            amount: coin.amount.to_string(),
-        }),
-    };
-
-    #[cfg(feature = "sei")]
-    let burn_msg = MsgBurn {
         amount: Some(ProtoCoin {
             denom: coin.denom,
             amount: coin.amount.to_string(),

--- a/packages/astroport_pcl_common/Cargo.toml
+++ b/packages/astroport_pcl_common/Cargo.toml
@@ -9,10 +9,6 @@ homepage = "https://astroport.fi"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-injective = ["astroport/injective"]
-sei = ["astroport/sei"]
-
 [dependencies]
 cosmwasm-std.workspace = true
 cosmwasm-schema.workspace = true

--- a/packages/astroport_pcl_common/src/utils.rs
+++ b/packages/astroport_pcl_common/src/utils.rs
@@ -18,9 +18,6 @@ use crate::error::PclError;
 use crate::state::{Config, PoolParams, PriceState};
 use crate::{calc_d, calc_y};
 
-#[cfg(any(feature = "injective", feature = "sei"))]
-use cosmwasm_std::BankMsg;
-
 /// Helper function to check the given asset infos are valid.
 pub fn check_asset_infos(api: &dyn Api, asset_infos: &[AssetInfo]) -> Result<(), PclError> {
     if !asset_infos.iter().all_unique() {

--- a/packages/astroport_test/Cargo.toml
+++ b/packages/astroport_test/Cargo.toml
@@ -11,7 +11,6 @@ homepage = "https://astroport.fi"
 [features]
 default = []
 injective = []
-sei = []
 cosmwasm_1_1 = ["cosmwasm-std/cosmwasm_1_1", "cw-multi-test/cosmwasm_1_1"]
 cosmwasm_1_2 = ["cosmwasm_1_1", "cosmwasm-std/cosmwasm_1_2", "cw-multi-test/cosmwasm_1_2"]
 cosmwasm_1_3 = ["cosmwasm_1_2", "cosmwasm-std/cosmwasm_1_3", "cw-multi-test/cosmwasm_1_3"]

--- a/packages/astroport_test/src/modules/stargate.rs
+++ b/packages/astroport_test/src/modules/stargate.rs
@@ -60,9 +60,9 @@ impl Module for MockStargate {
         match type_url.as_str() {
             MsgCreateDenom::TYPE_URL => {
                 let tf_msg: MsgCreateDenom = value.try_into()?;
-                #[cfg(not(any(feature = "injective", feature = "sei")))]
+                #[cfg(not(feature = "injective"))]
                 let sender_address = tf_msg.sender.to_string();
-                #[cfg(any(feature = "injective", feature = "sei"))]
+                #[cfg(feature = "injective")]
                 let sender_address = sender.to_string();
                 let submsg_response = SubMsgResponse {
                     events: vec![],
@@ -83,9 +83,9 @@ impl Module for MockStargate {
                 let mint_coins = tf_msg
                     .amount
                     .expect("Empty amount in tokenfactory MsgMint!");
-                #[cfg(not(any(feature = "injective", feature = "sei")))]
+                #[cfg(not(feature = "injective"))]
                 let to_address = tf_msg.mint_to_address.to_string();
-                #[cfg(any(feature = "injective", feature = "sei"))]
+                #[cfg(feature = "injective")]
                 let to_address = sender.to_string();
                 let bank_sudo = BankSudo::Mint {
                     to_address,


### PR DESCRIPTION
Anyway, TF LP tokens never worked on Sei due to their incompatible wasmd which doesn't support cosmwasm_1_1 interface